### PR TITLE
fix(suggest):  set disabled markForCheck

### DIFF
--- a/projects/angular/components/ui-suggest/src/ui-suggest.component.ts
+++ b/projects/angular/components/ui-suggest/src/ui-suggest.component.ts
@@ -118,8 +118,9 @@ export class UiSuggestComponent extends UiSuggestMatFormField
         ) {
             this.close(false);
         }
+
+        this._cd.markForCheck();
         this.stateChanges.next();
-        this._cd.detectChanges();
     }
 
     /**


### PR DESCRIPTION
- on set disabled replace detectChanges w markForCheck
- in case the viewRef has been destroyed detectChanges throws error, we should just mark for check