### PR TITLE
fix(suggest): remove tooltip after selection

### DIFF
--- a/projects/angular/components/ui-suggest/src/ui-suggest.component.html
+++ b/projects/angular/components/ui-suggest/src/ui-suggest.component.html
@@ -124,7 +124,7 @@
             <ng-container *ngTemplateOutlet="customValueTemplate; context: { $implicit: 'down' }">
             </ng-container>
 
-            <ng-container *cdkVirtualFor="let item of renderItems; let index = index; trackBy: trackById">
+            <ng-container *cdkVirtualFor="let item of renderItems; let index = index; trackBy: trackById; templateCacheSize: disableTooltip ? 20 : 0">
                 <mat-list-item [class.active]="index === activeIndex"
                                [class.is-loading]="item.loading !== VirtualScrollItemStatus.loaded"
                                [class.readonly]="item.loading !== VirtualScrollItemStatus.loaded"


### PR DESCRIPTION
workaround for https://github.com/angular/components/issues/15648

this is a fix for the case when the tooltip gets 'hanged' after closing the virtual scrolled list