### PR TITLE
feat(snackbar): allow zero as duration

### DIFF
--- a/projects/angular/components/ui-snackbar/src/ui-snackbar.component.spec.ts
+++ b/projects/angular/components/ui-snackbar/src/ui-snackbar.component.spec.ts
@@ -207,11 +207,23 @@ describe('Service: UiSnackBarService', () => {
 
                 tick(DEFAULT_DURATION - 1);
                 const snackBeforeTimeout = getSnack();
-                expect(snackBeforeTimeout).toBeDefined();
+                expect(snackBeforeTimeout).not.toBeNull();
 
                 tick(1);
                 const snackAfterTimeout = getSnack();
-                expect(snackAfterTimeout).toBeDefined();
+                expect(snackAfterTimeout).toBeNull();
+            }));
+
+            it('should not dismiss after the default duration if the duration is zero', fakeAsync(() => {
+                const method = getMethodFor(type);
+
+                method(faker.lorem.paragraph(), 0);
+                fixture.detectChanges();
+
+                tick(DEFAULT_DURATION + 1);
+
+                const snackAfterDefaultTimeout = getSnack();
+                expect(snackAfterDefaultTimeout).not.toBeNull();
             }));
         });
 

--- a/projects/angular/components/ui-snackbar/src/ui-snackbar.component.ts
+++ b/projects/angular/components/ui-snackbar/src/ui-snackbar.component.ts
@@ -149,7 +149,7 @@ export class UiSnackBarService {
         this._alert(type || SnackBarType.None, {
             message,
             icon: icon || ICON_MAP.get(type!),
-            duration: duration || this._options.duration!,
+            duration: duration || duration === 0 ? duration : this._options.duration!,
         })
 
     /**
@@ -165,7 +165,7 @@ export class UiSnackBarService {
         (message: string | TemplateRef<any>, duration?: number) => this._alert(type, {
             message,
             icon: ICON_MAP.get(type),
-            duration: duration || this._options.duration!,
+            duration: duration || duration === 0 ? duration : this._options.duration!,
         })
 
     private _alert(type: SnackBarType, options: ISnackBarAlert) {


### PR DESCRIPTION
`MatSnackBar` accepts zero as duration which means that the snack bar will not be hidden.
This PR modifies `UiSnackBarService` to have the same behavior.

## How to test
- using `UiSnackBarService`, open a snackbar using zero as duration

expected: the snackbar should stay on screen indefinitely