### PR TITLE
fix(grid): remove cdk experimental (issues with scrolling on firefox)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+#v9.0.3 (2020-03-20)
+* **grid** replace autosize with itemSize (until autosize becomes production-ready)
+
 # v9.0.2 (2020-03-16)
 * **snackbar** show snackbars with 0 delay (that don't auto-close)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "angular-components",
-  "version": "9.0.2",
+  "version": "9.0.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -452,7 +452,7 @@
       "dependencies": {
         "ansi-regex": {
           "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "resolved": "https://uipath.pkgs.visualstudio.com/_packaging/npm-packages/npm/registry/ansi-regex/-/ansi-regex-3.0.0.tgz",
           "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
           "dev": true
         },
@@ -594,7 +594,7 @@
         },
         "is-fullwidth-code-point": {
           "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+          "resolved": "https://uipath.pkgs.visualstudio.com/_packaging/npm-packages/npm/registry/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
           "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
           "dev": true
         },
@@ -634,7 +634,7 @@
         },
         "minimist": {
           "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "resolved": "https://uipath.pkgs.visualstudio.com/_packaging/npm-packages/npm/registry/minimist/-/minimist-1.2.0.tgz",
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
           "dev": true
         },
@@ -736,7 +736,7 @@
         },
         "strip-ansi": {
           "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+          "resolved": "https://uipath.pkgs.visualstudio.com/_packaging/npm-packages/npm/registry/strip-ansi/-/strip-ansi-4.0.0.tgz",
           "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
           "dev": true,
           "requires": {
@@ -754,7 +754,7 @@
         },
         "which-module": {
           "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
+          "resolved": "https://uipath.pkgs.visualstudio.com/_packaging/npm-packages/npm/registry/which-module/-/which-module-2.0.0.tgz",
           "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
           "dev": true
         },
@@ -4826,7 +4826,7 @@
     },
     "ansi-html": {
       "version": "0.0.7",
-      "resolved": "https://registry.npmjs.org/ansi-html/-/ansi-html-0.0.7.tgz",
+      "resolved": "https://uipath.pkgs.visualstudio.com/_packaging/npm-packages/npm/registry/ansi-html/-/ansi-html-0.0.7.tgz",
       "integrity": "sha1-gTWEAhliqenm/QOflA0S9WynhZ4=",
       "dev": true
     },
@@ -4930,7 +4930,7 @@
     },
     "aria-query": {
       "version": "3.0.0",
-      "resolved": "https://uipath.pkgs.visualstudio.com/_packaging/npm-packages/npm/registry/aria-query/-/aria-query-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-3.0.0.tgz",
       "integrity": "sha1-ZbP8wcoRVajJrmTW7uKX8V1RM8w=",
       "dev": true,
       "requires": {
@@ -5069,13 +5069,13 @@
       "dependencies": {
         "inherits": {
           "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+          "resolved": "https://uipath.pkgs.visualstudio.com/_packaging/npm-packages/npm/registry/inherits/-/inherits-2.0.1.tgz",
           "integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE=",
           "dev": true
         },
         "util": {
           "version": "0.10.3",
-          "resolved": "https://registry.npmjs.org/util/-/util-0.10.3.tgz",
+          "resolved": "https://uipath.pkgs.visualstudio.com/_packaging/npm-packages/npm/registry/util/-/util-0.10.3.tgz",
           "integrity": "sha1-evsa/lCAUkZInj23/g7TeTNqwPk=",
           "dev": true,
           "requires": {
@@ -5157,7 +5157,7 @@
     },
     "ast-types-flow": {
       "version": "0.0.7",
-      "resolved": "https://uipath.pkgs.visualstudio.com/_packaging/npm-packages/npm/registry/ast-types-flow/-/ast-types-flow-0.0.7.tgz",
+      "resolved": "https://registry.npmjs.org/ast-types-flow/-/ast-types-flow-0.0.7.tgz",
       "integrity": "sha1-9wtzXGvKGlycItmCw+Oef+ujva0=",
       "dev": true
     },
@@ -5565,7 +5565,7 @@
     },
     "bonjour": {
       "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/bonjour/-/bonjour-3.5.0.tgz",
+      "resolved": "https://uipath.pkgs.visualstudio.com/_packaging/npm-packages/npm/registry/bonjour/-/bonjour-3.5.0.tgz",
       "integrity": "sha1-jokKGD2O6aI5OzhExpGkK897yfU=",
       "dev": true,
       "requires": {
@@ -5754,7 +5754,7 @@
     },
     "brorand": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
+      "resolved": "https://uipath.pkgs.visualstudio.com/_packaging/npm-packages/npm/registry/brorand/-/brorand-1.1.0.tgz",
       "integrity": "sha1-EsJe/kCkXjwyPrhnWgoM5XsiNx8=",
       "dev": true
     },
@@ -5826,7 +5826,7 @@
     },
     "browserify-rsa": {
       "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.0.1.tgz",
+      "resolved": "https://uipath.pkgs.visualstudio.com/_packaging/npm-packages/npm/registry/browserify-rsa/-/browserify-rsa-4.0.1.tgz",
       "integrity": "sha1-IeCr+vbyApzy+vsTNWenAdQTVSQ=",
       "dev": true,
       "requires": {
@@ -5836,7 +5836,7 @@
     },
     "browserify-sign": {
       "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/browserify-sign/-/browserify-sign-4.0.4.tgz",
+      "resolved": "https://uipath.pkgs.visualstudio.com/_packaging/npm-packages/npm/registry/browserify-sign/-/browserify-sign-4.0.4.tgz",
       "integrity": "sha1-qk62jl17ZYuqa/alfmMMvXqT0pg=",
       "dev": true,
       "requires": {
@@ -5937,7 +5937,7 @@
     },
     "buffer-xor": {
       "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/buffer-xor/-/buffer-xor-1.0.3.tgz",
+      "resolved": "https://uipath.pkgs.visualstudio.com/_packaging/npm-packages/npm/registry/buffer-xor/-/buffer-xor-1.0.3.tgz",
       "integrity": "sha1-JuYe0UIvtw3ULm42cp7VHYVf6Nk=",
       "dev": true
     },
@@ -5949,19 +5949,19 @@
     },
     "builtin-status-codes": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/builtin-status-codes/-/builtin-status-codes-3.0.0.tgz",
+      "resolved": "https://uipath.pkgs.visualstudio.com/_packaging/npm-packages/npm/registry/builtin-status-codes/-/builtin-status-codes-3.0.0.tgz",
       "integrity": "sha1-hZgoeOIbmOHGZCXgPQF0eI9Wnug=",
       "dev": true
     },
     "builtins": {
       "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/builtins/-/builtins-1.0.3.tgz",
+      "resolved": "https://uipath.pkgs.visualstudio.com/_packaging/npm-packages/npm/registry/builtins/-/builtins-1.0.3.tgz",
       "integrity": "sha1-y5T662HIaWRR2zZTThQi+U8K7og=",
       "dev": true
     },
     "bytes": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.0.0.tgz",
+      "resolved": "https://uipath.pkgs.visualstudio.com/_packaging/npm-packages/npm/registry/bytes/-/bytes-3.0.0.tgz",
       "integrity": "sha1-0ygVQE1olpn4Wk6k+odV3ROpYEg=",
       "dev": true
     },
@@ -6453,7 +6453,7 @@
       "dependencies": {
         "source-map": {
           "version": "0.5.7",
-          "resolved": "https://uipath.pkgs.visualstudio.com/_packaging/npm-packages/npm/registry/source-map/-/source-map-0.5.7.tgz",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
           "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
           "dev": true
         },
@@ -6659,7 +6659,7 @@
     },
     "commondir": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
+      "resolved": "https://uipath.pkgs.visualstudio.com/_packaging/npm-packages/npm/registry/commondir/-/commondir-1.0.1.tgz",
       "integrity": "sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs=",
       "dev": true
     },
@@ -6864,7 +6864,7 @@
     },
     "constants-browserify": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/constants-browserify/-/constants-browserify-1.0.0.tgz",
+      "resolved": "https://uipath.pkgs.visualstudio.com/_packaging/npm-packages/npm/registry/constants-browserify/-/constants-browserify-1.0.0.tgz",
       "integrity": "sha1-wguW2MYXdIqvHBYCF2DNJ/y4y3U=",
       "dev": true
     },
@@ -7064,7 +7064,7 @@
     },
     "cookie-signature": {
       "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
+      "resolved": "https://uipath.pkgs.visualstudio.com/_packaging/npm-packages/npm/registry/cookie-signature/-/cookie-signature-1.0.6.tgz",
       "integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw=",
       "dev": true
     },
@@ -7257,7 +7257,7 @@
       "dependencies": {
         "parse-json": {
           "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
+          "resolved": "https://uipath.pkgs.visualstudio.com/_packaging/npm-packages/npm/registry/parse-json/-/parse-json-4.0.0.tgz",
           "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
           "dev": true,
           "requires": {
@@ -7658,7 +7658,7 @@
     },
     "cssauron": {
       "version": "1.4.0",
-      "resolved": "https://uipath.pkgs.visualstudio.com/_packaging/npm-packages/npm/registry/cssauron/-/cssauron-1.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/cssauron/-/cssauron-1.4.0.tgz",
       "integrity": "sha1-pmAt/34EqDBtwNuaVR6S6LVmKtg=",
       "dev": true,
       "requires": {
@@ -7667,7 +7667,7 @@
     },
     "cssesc": {
       "version": "0.1.0",
-      "resolved": "https://uipath.pkgs.visualstudio.com/_packaging/npm-packages/npm/registry/cssesc/-/cssesc-0.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-0.1.0.tgz",
       "integrity": "sha1-yBSQPkViM3GgR3tAEJqq++6t27Q=",
       "dev": true
     },
@@ -8020,7 +8020,7 @@
       "dependencies": {
         "globby": {
           "version": "6.1.0",
-          "resolved": "https://registry.npmjs.org/globby/-/globby-6.1.0.tgz",
+          "resolved": "https://uipath.pkgs.visualstudio.com/_packaging/npm-packages/npm/registry/globby/-/globby-6.1.0.tgz",
           "integrity": "sha1-9abXDoOV4hyFj7BInWTfAkJNUGw=",
           "dev": true,
           "requires": {
@@ -8033,7 +8033,7 @@
           "dependencies": {
             "pify": {
               "version": "2.3.0",
-              "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+              "resolved": "https://uipath.pkgs.visualstudio.com/_packaging/npm-packages/npm/registry/pify/-/pify-2.3.0.tgz",
               "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
               "dev": true
             }
@@ -8190,7 +8190,7 @@
     },
     "dns-equal": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/dns-equal/-/dns-equal-1.0.0.tgz",
+      "resolved": "https://uipath.pkgs.visualstudio.com/_packaging/npm-packages/npm/registry/dns-equal/-/dns-equal-1.0.0.tgz",
       "integrity": "sha1-s55/HabrCnW6nBcySzR1PEfgZU0=",
       "dev": true
     },
@@ -8206,7 +8206,7 @@
     },
     "dns-txt": {
       "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/dns-txt/-/dns-txt-2.0.2.tgz",
+      "resolved": "https://uipath.pkgs.visualstudio.com/_packaging/npm-packages/npm/registry/dns-txt/-/dns-txt-2.0.2.tgz",
       "integrity": "sha1-uR2Ab10nGI5Ks+fRB9iBocxGQrY=",
       "dev": true,
       "requires": {
@@ -8373,7 +8373,7 @@
     },
     "emojis-list": {
       "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-2.1.0.tgz",
+      "resolved": "https://uipath.pkgs.visualstudio.com/_packaging/npm-packages/npm/registry/emojis-list/-/emojis-list-2.1.0.tgz",
       "integrity": "sha1-TapNnbAPmBmIDHn6RXrlsJof04k=",
       "dev": true
     },
@@ -8385,7 +8385,7 @@
     },
     "encoding": {
       "version": "0.1.12",
-      "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
+      "resolved": "https://uipath.pkgs.visualstudio.com/_packaging/npm-packages/npm/registry/encoding/-/encoding-0.1.12.tgz",
       "integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
       "dev": true,
       "requires": {
@@ -8500,7 +8500,7 @@
     },
     "err-code": {
       "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/err-code/-/err-code-1.1.2.tgz",
+      "resolved": "https://uipath.pkgs.visualstudio.com/_packaging/npm-packages/npm/registry/err-code/-/err-code-1.1.2.tgz",
       "integrity": "sha1-BuARbTAo9q70gGhJ6w6mp0iuaWA=",
       "dev": true
     },
@@ -8902,7 +8902,7 @@
         },
         "array-flatten": {
           "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
+          "resolved": "https://uipath.pkgs.visualstudio.com/_packaging/npm-packages/npm/registry/array-flatten/-/array-flatten-1.1.1.tgz",
           "integrity": "sha1-ml9pkFGx5wczKPKgCJaLZOopVdI=",
           "dev": true
         },
@@ -8947,7 +8947,7 @@
         },
         "statuses": {
           "version": "1.5.0",
-          "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
+          "resolved": "https://uipath.pkgs.visualstudio.com/_packaging/npm-packages/npm/registry/statuses/-/statuses-1.5.0.tgz",
           "integrity": "sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow=",
           "dev": true
         }
@@ -9157,7 +9157,7 @@
     },
     "faye-websocket": {
       "version": "0.10.0",
-      "resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.10.0.tgz",
+      "resolved": "https://uipath.pkgs.visualstudio.com/_packaging/npm-packages/npm/registry/faye-websocket/-/faye-websocket-0.10.0.tgz",
       "integrity": "sha1-TkkvjQTftviQA1B/btvy1QHnxvQ=",
       "dev": true,
       "requires": {
@@ -9308,7 +9308,7 @@
         },
         "statuses": {
           "version": "1.5.0",
-          "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
+          "resolved": "https://uipath.pkgs.visualstudio.com/_packaging/npm-packages/npm/registry/statuses/-/statuses-1.5.0.tgz",
           "integrity": "sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow=",
           "dev": true
         }
@@ -9463,7 +9463,7 @@
     },
     "flush-write-stream": {
       "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/flush-write-stream/-/flush-write-stream-1.1.1.tgz",
+      "resolved": "https://uipath.pkgs.visualstudio.com/_packaging/npm-packages/npm/registry/flush-write-stream/-/flush-write-stream-1.1.1.tgz",
       "integrity": "sha512-3Z4XhFZ3992uIq0XOqb9AreonueSYphE6oYbpt5+3u06JWklbsPkNv3ZKkP9Bz/r+1MWCaMoSQ28P85+1Yc77w==",
       "dev": true,
       "requires": {
@@ -9555,7 +9555,7 @@
     },
     "forwarded": {
       "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.1.2.tgz",
+      "resolved": "https://uipath.pkgs.visualstudio.com/_packaging/npm-packages/npm/registry/forwarded/-/forwarded-0.1.2.tgz",
       "integrity": "sha1-mMI9qxF1ZXuMBXPozszZGw/xjIQ=",
       "dev": true
     },
@@ -9582,7 +9582,7 @@
     },
     "from2": {
       "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/from2/-/from2-2.3.0.tgz",
+      "resolved": "https://uipath.pkgs.visualstudio.com/_packaging/npm-packages/npm/registry/from2/-/from2-2.3.0.tgz",
       "integrity": "sha1-i/tVAr3kpNNs/e6gB/zKIdfjgq8=",
       "dev": true,
       "requires": {
@@ -9621,7 +9621,7 @@
     },
     "fs-write-stream-atomic": {
       "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/fs-write-stream-atomic/-/fs-write-stream-atomic-1.0.10.tgz",
+      "resolved": "https://uipath.pkgs.visualstudio.com/_packaging/npm-packages/npm/registry/fs-write-stream-atomic/-/fs-write-stream-atomic-1.0.10.tgz",
       "integrity": "sha1-tH31NJPvkR33VzHnCp3tAYnbQMk=",
       "dev": true,
       "requires": {
@@ -10578,7 +10578,7 @@
     },
     "globby": {
       "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/globby/-/globby-7.1.1.tgz",
+      "resolved": "https://uipath.pkgs.visualstudio.com/_packaging/npm-packages/npm/registry/globby/-/globby-7.1.1.tgz",
       "integrity": "sha1-+yzP+UAfhgCUXfral0QMypcrhoA=",
       "dev": true,
       "requires": {
@@ -10784,7 +10784,7 @@
     },
     "hash-base": {
       "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/hash-base/-/hash-base-3.0.4.tgz",
+      "resolved": "https://uipath.pkgs.visualstudio.com/_packaging/npm-packages/npm/registry/hash-base/-/hash-base-3.0.4.tgz",
       "integrity": "sha1-X8hoaEfs1zSZQDMZprCj8/auSRg=",
       "dev": true,
       "requires": {
@@ -10810,7 +10810,7 @@
     },
     "hmac-drbg": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
+      "resolved": "https://uipath.pkgs.visualstudio.com/_packaging/npm-packages/npm/registry/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
       "integrity": "sha1-0nRXAQJabHdabFRXk+1QL8DGSaE=",
       "dev": true,
       "requires": {
@@ -10836,7 +10836,7 @@
     },
     "hpack.js": {
       "version": "2.1.6",
-      "resolved": "https://registry.npmjs.org/hpack.js/-/hpack.js-2.1.6.tgz",
+      "resolved": "https://uipath.pkgs.visualstudio.com/_packaging/npm-packages/npm/registry/hpack.js/-/hpack.js-2.1.6.tgz",
       "integrity": "sha1-h3dMCUnlE/QuhFdbPEVoH63ioLI=",
       "dev": true,
       "requires": {
@@ -10917,7 +10917,7 @@
     },
     "http-deceiver": {
       "version": "1.2.7",
-      "resolved": "https://registry.npmjs.org/http-deceiver/-/http-deceiver-1.2.7.tgz",
+      "resolved": "https://uipath.pkgs.visualstudio.com/_packaging/npm-packages/npm/registry/http-deceiver/-/http-deceiver-1.2.7.tgz",
       "integrity": "sha1-+nFolEq5pRnTN8sL7HKE3D5yPYc=",
       "dev": true
     },
@@ -10996,7 +10996,7 @@
     },
     "https-browserify": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/https-browserify/-/https-browserify-1.0.0.tgz",
+      "resolved": "https://uipath.pkgs.visualstudio.com/_packaging/npm-packages/npm/registry/https-browserify/-/https-browserify-1.0.0.tgz",
       "integrity": "sha1-7AbBDgo0wPL68Zn3/X/Hj//QPHM=",
       "dev": true
     },
@@ -11038,7 +11038,7 @@
     },
     "humanize-ms": {
       "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/humanize-ms/-/humanize-ms-1.2.1.tgz",
+      "resolved": "https://uipath.pkgs.visualstudio.com/_packaging/npm-packages/npm/registry/humanize-ms/-/humanize-ms-1.2.1.tgz",
       "integrity": "sha1-xG4xWaKT9riW2ikxbYtv6Lt5u+0=",
       "dev": true,
       "requires": {
@@ -11275,7 +11275,7 @@
     },
     "iferr": {
       "version": "0.1.5",
-      "resolved": "https://registry.npmjs.org/iferr/-/iferr-0.1.5.tgz",
+      "resolved": "https://uipath.pkgs.visualstudio.com/_packaging/npm-packages/npm/registry/iferr/-/iferr-0.1.5.tgz",
       "integrity": "sha1-xg7taebY/bazEEofy8ocGS3FtQE=",
       "dev": true
     },
@@ -11309,7 +11309,7 @@
     },
     "import-cwd": {
       "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/import-cwd/-/import-cwd-2.1.0.tgz",
+      "resolved": "https://uipath.pkgs.visualstudio.com/_packaging/npm-packages/npm/registry/import-cwd/-/import-cwd-2.1.0.tgz",
       "integrity": "sha1-qmzzbnInYShcs3HsZRn1PiQ1sKk=",
       "dev": true,
       "requires": {
@@ -11328,7 +11328,7 @@
     },
     "import-from": {
       "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/import-from/-/import-from-2.1.0.tgz",
+      "resolved": "https://uipath.pkgs.visualstudio.com/_packaging/npm-packages/npm/registry/import-from/-/import-from-2.1.0.tgz",
       "integrity": "sha1-M1238qev/VOqpHHUuAId7ja387E=",
       "dev": true,
       "requires": {
@@ -11613,13 +11613,13 @@
     },
     "ip": {
       "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/ip/-/ip-1.1.5.tgz",
+      "resolved": "https://uipath.pkgs.visualstudio.com/_packaging/npm-packages/npm/registry/ip/-/ip-1.1.5.tgz",
       "integrity": "sha1-vd7XARQpCCjAoDnnLvJfWq7ENUo=",
       "dev": true
     },
     "ip-regex": {
       "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/ip-regex/-/ip-regex-2.1.0.tgz",
+      "resolved": "https://uipath.pkgs.visualstudio.com/_packaging/npm-packages/npm/registry/ip-regex/-/ip-regex-2.1.0.tgz",
       "integrity": "sha1-+ni/XS5pE8kRzp+BnuUUa7bYROk=",
       "dev": true
     },
@@ -12611,7 +12611,7 @@
       "dependencies": {
         "minimist": {
           "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "resolved": "https://uipath.pkgs.visualstudio.com/_packaging/npm-packages/npm/registry/minimist/-/minimist-1.2.0.tgz",
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
           "dev": true
         }
@@ -13118,7 +13118,7 @@
     },
     "lodash.clonedeep": {
       "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
+      "resolved": "https://uipath.pkgs.visualstudio.com/_packaging/npm-packages/npm/registry/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
       "integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8=",
       "dev": true
     },
@@ -13577,7 +13577,7 @@
     },
     "merge-descriptors": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
+      "resolved": "https://uipath.pkgs.visualstudio.com/_packaging/npm-packages/npm/registry/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
       "integrity": "sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E=",
       "dev": true
     },
@@ -13612,7 +13612,7 @@
     },
     "methods": {
       "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
+      "resolved": "https://uipath.pkgs.visualstudio.com/_packaging/npm-packages/npm/registry/methods/-/methods-1.1.2.tgz",
       "integrity": "sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4=",
       "dev": true
     },
@@ -13700,7 +13700,7 @@
     },
     "minimalistic-crypto-utils": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz",
+      "resolved": "https://uipath.pkgs.visualstudio.com/_packaging/npm-packages/npm/registry/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz",
       "integrity": "sha1-9sAMHAsIIkblxNmd+4x8CDsrWCo=",
       "dev": true
     },
@@ -13876,7 +13876,7 @@
     },
     "move-concurrently": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/move-concurrently/-/move-concurrently-1.0.1.tgz",
+      "resolved": "https://uipath.pkgs.visualstudio.com/_packaging/npm-packages/npm/registry/move-concurrently/-/move-concurrently-1.0.1.tgz",
       "integrity": "sha1-viwAX9oy4LKa8fBdfEszIUxwH5I=",
       "dev": true,
       "requires": {
@@ -13906,7 +13906,7 @@
     },
     "multicast-dns-service-types": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/multicast-dns-service-types/-/multicast-dns-service-types-1.1.0.tgz",
+      "resolved": "https://uipath.pkgs.visualstudio.com/_packaging/npm-packages/npm/registry/multicast-dns-service-types/-/multicast-dns-service-types-1.1.0.tgz",
       "integrity": "sha1-iZ8R2WhuXgXLkbNdXw5jt3PPyQE=",
       "dev": true
     },
@@ -14400,7 +14400,7 @@
       "dependencies": {
         "punycode": {
           "version": "1.4.1",
-          "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+          "resolved": "https://uipath.pkgs.visualstudio.com/_packaging/npm-packages/npm/registry/punycode/-/punycode-1.4.1.tgz",
           "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
           "dev": true
         }
@@ -14456,13 +14456,13 @@
       "dependencies": {
         "ansi-styles": {
           "version": "2.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+          "resolved": "https://uipath.pkgs.visualstudio.com/_packaging/npm-packages/npm/registry/ansi-styles/-/ansi-styles-2.2.1.tgz",
           "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
           "dev": true
         },
         "chalk": {
           "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "resolved": "https://uipath.pkgs.visualstudio.com/_packaging/npm-packages/npm/registry/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
@@ -14487,7 +14487,7 @@
         },
         "supports-color": {
           "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+          "resolved": "https://uipath.pkgs.visualstudio.com/_packaging/npm-packages/npm/registry/supports-color/-/supports-color-2.0.0.tgz",
           "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
           "dev": true
         }
@@ -15230,7 +15230,7 @@
     },
     "os-browserify": {
       "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/os-browserify/-/os-browserify-0.3.0.tgz",
+      "resolved": "https://uipath.pkgs.visualstudio.com/_packaging/npm-packages/npm/registry/os-browserify/-/os-browserify-0.3.0.tgz",
       "integrity": "sha1-hUNzx/XCMVkU/Jv8a9gjj92h7Cc=",
       "dev": true
     },
@@ -15673,7 +15673,7 @@
     },
     "path-to-regexp": {
       "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
+      "resolved": "https://uipath.pkgs.visualstudio.com/_packaging/npm-packages/npm/registry/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
       "integrity": "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w=",
       "dev": true
     },
@@ -16511,7 +16511,7 @@
     },
     "process": {
       "version": "0.11.10",
-      "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
+      "resolved": "https://uipath.pkgs.visualstudio.com/_packaging/npm-packages/npm/registry/process/-/process-0.11.10.tgz",
       "integrity": "sha1-czIwDoQBYb2j5podHZGn1LwW8YI=",
       "dev": true
     },
@@ -16533,13 +16533,13 @@
     },
     "promise-inflight": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/promise-inflight/-/promise-inflight-1.0.1.tgz",
+      "resolved": "https://uipath.pkgs.visualstudio.com/_packaging/npm-packages/npm/registry/promise-inflight/-/promise-inflight-1.0.1.tgz",
       "integrity": "sha1-mEcocL8igTL8vdhoEputEsPAKeM=",
       "dev": true
     },
     "promise-retry": {
       "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/promise-retry/-/promise-retry-1.1.1.tgz",
+      "resolved": "https://uipath.pkgs.visualstudio.com/_packaging/npm-packages/npm/registry/promise-retry/-/promise-retry-1.1.1.tgz",
       "integrity": "sha1-ZznpaOMFHaIM5kl/srUPaRHfPW0=",
       "dev": true,
       "requires": {
@@ -16806,13 +16806,13 @@
     },
     "querystring": {
       "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
+      "resolved": "https://uipath.pkgs.visualstudio.com/_packaging/npm-packages/npm/registry/querystring/-/querystring-0.2.0.tgz",
       "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA=",
       "dev": true
     },
     "querystring-es3": {
       "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/querystring-es3/-/querystring-es3-0.2.1.tgz",
+      "resolved": "https://uipath.pkgs.visualstudio.com/_packaging/npm-packages/npm/registry/querystring-es3/-/querystring-es3-0.2.1.tgz",
       "integrity": "sha1-nsYfeQSYdXB9aUFFlv2Qek1xHnM=",
       "dev": true
     },
@@ -17007,7 +17007,7 @@
     },
     "read-cache": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/read-cache/-/read-cache-1.0.0.tgz",
+      "resolved": "https://uipath.pkgs.visualstudio.com/_packaging/npm-packages/npm/registry/read-cache/-/read-cache-1.0.0.tgz",
       "integrity": "sha1-5mTvMRYRZsl1HNvo28+GtftY93Q=",
       "dev": true,
       "requires": {
@@ -17016,7 +17016,7 @@
       "dependencies": {
         "pify": {
           "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+          "resolved": "https://uipath.pkgs.visualstudio.com/_packaging/npm-packages/npm/registry/pify/-/pify-2.3.0.tgz",
           "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
           "dev": true
         }
@@ -17240,7 +17240,7 @@
     },
     "regexpu-core": {
       "version": "1.0.0",
-      "resolved": "https://uipath.pkgs.visualstudio.com/_packaging/npm-packages/npm/registry/regexpu-core/-/regexpu-core-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-1.0.0.tgz",
       "integrity": "sha1-hqdj9Y7k18L2sQLkdkBQ3n7ZDGs=",
       "dev": true,
       "requires": {
@@ -17269,13 +17269,13 @@
     },
     "regjsgen": {
       "version": "0.2.0",
-      "resolved": "https://uipath.pkgs.visualstudio.com/_packaging/npm-packages/npm/registry/regjsgen/-/regjsgen-0.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.2.0.tgz",
       "integrity": "sha1-bAFq3qxVT3WCP+N6wFuS1aTtsfc=",
       "dev": true
     },
     "regjsparser": {
       "version": "0.1.5",
-      "resolved": "https://uipath.pkgs.visualstudio.com/_packaging/npm-packages/npm/registry/regjsparser/-/regjsparser-0.1.5.tgz",
+      "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.1.5.tgz",
       "integrity": "sha1-fuj4Tcb6eS0/0K4ijSS9lJ6tIFw=",
       "dev": true,
       "requires": {
@@ -17284,7 +17284,7 @@
       "dependencies": {
         "jsesc": {
           "version": "0.5.0",
-          "resolved": "https://uipath.pkgs.visualstudio.com/_packaging/npm-packages/npm/registry/jsesc/-/jsesc-0.5.0.tgz",
+          "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
           "integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0=",
           "dev": true
         }
@@ -17371,7 +17371,7 @@
     },
     "resolve-cwd": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/resolve-cwd/-/resolve-cwd-2.0.0.tgz",
+      "resolved": "https://uipath.pkgs.visualstudio.com/_packaging/npm-packages/npm/registry/resolve-cwd/-/resolve-cwd-2.0.0.tgz",
       "integrity": "sha1-AKn3OHVW4nA46uIyyqNypqWbZlo=",
       "dev": true,
       "requires": {
@@ -17545,7 +17545,7 @@
     },
     "run-queue": {
       "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/run-queue/-/run-queue-1.0.3.tgz",
+      "resolved": "https://uipath.pkgs.visualstudio.com/_packaging/npm-packages/npm/registry/run-queue/-/run-queue-1.0.3.tgz",
       "integrity": "sha1-6Eg5bwV9Ij8kOGkkYY4laUFh7Ec=",
       "dev": true,
       "requires": {
@@ -18055,7 +18055,7 @@
     },
     "select-hose": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/select-hose/-/select-hose-2.0.0.tgz",
+      "resolved": "https://uipath.pkgs.visualstudio.com/_packaging/npm-packages/npm/registry/select-hose/-/select-hose-2.0.0.tgz",
       "integrity": "sha1-Yl2GWPhlr0Psliv8N2o3NZpJlMo=",
       "dev": true
     },
@@ -18122,7 +18122,7 @@
     },
     "semver-dsl": {
       "version": "1.0.1",
-      "resolved": "https://uipath.pkgs.visualstudio.com/_packaging/npm-packages/npm/registry/semver-dsl/-/semver-dsl-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/semver-dsl/-/semver-dsl-1.0.1.tgz",
       "integrity": "sha1-02eN5VVeimH2Ke7QJTZq5fJzQKA=",
       "dev": true,
       "requires": {
@@ -18192,7 +18192,7 @@
         },
         "statuses": {
           "version": "1.5.0",
-          "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
+          "resolved": "https://uipath.pkgs.visualstudio.com/_packaging/npm-packages/npm/registry/statuses/-/statuses-1.5.0.tgz",
           "integrity": "sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow=",
           "dev": true
         }
@@ -18276,7 +18276,7 @@
     },
     "setimmediate": {
       "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
+      "resolved": "https://uipath.pkgs.visualstudio.com/_packaging/npm-packages/npm/registry/setimmediate/-/setimmediate-1.0.5.tgz",
       "integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU=",
       "dev": true
     },
@@ -19673,7 +19673,7 @@
     },
     "to-arraybuffer": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/to-arraybuffer/-/to-arraybuffer-1.0.1.tgz",
+      "resolved": "https://uipath.pkgs.visualstudio.com/_packaging/npm-packages/npm/registry/to-arraybuffer/-/to-arraybuffer-1.0.1.tgz",
       "integrity": "sha1-fSKbH8xjfkZsoIEYCDanqr/4P0M=",
       "dev": true
     },
@@ -19973,7 +19973,7 @@
     },
     "tty-browserify": {
       "version": "0.0.0",
-      "resolved": "https://registry.npmjs.org/tty-browserify/-/tty-browserify-0.0.0.tgz",
+      "resolved": "https://uipath.pkgs.visualstudio.com/_packaging/npm-packages/npm/registry/tty-browserify/-/tty-browserify-0.0.0.tgz",
       "integrity": "sha1-oVe6QC2iTpv5V/mqadUk7tQpAaY=",
       "dev": true
     },
@@ -20415,7 +20415,7 @@
     },
     "url": {
       "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/url/-/url-0.11.0.tgz",
+      "resolved": "https://uipath.pkgs.visualstudio.com/_packaging/npm-packages/npm/registry/url/-/url-0.11.0.tgz",
       "integrity": "sha1-ODjpfPxgUh63PFJajlW/3Z4uKPE=",
       "dev": true,
       "requires": {
@@ -20425,7 +20425,7 @@
       "dependencies": {
         "punycode": {
           "version": "1.3.2",
-          "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
+          "resolved": "https://uipath.pkgs.visualstudio.com/_packaging/npm-packages/npm/registry/punycode/-/punycode-1.3.2.tgz",
           "integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0=",
           "dev": true
         }
@@ -20605,7 +20605,7 @@
     },
     "validate-npm-package-name": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/validate-npm-package-name/-/validate-npm-package-name-3.0.0.tgz",
+      "resolved": "https://uipath.pkgs.visualstudio.com/_packaging/npm-packages/npm/registry/validate-npm-package-name/-/validate-npm-package-name-3.0.0.tgz",
       "integrity": "sha1-X6kS2B630MdK/BQN5zF/DKffQ34=",
       "dev": true,
       "requires": {
@@ -21061,7 +21061,7 @@
       "dependencies": {
         "ansi-regex": {
           "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "resolved": "https://uipath.pkgs.visualstudio.com/_packaging/npm-packages/npm/registry/ansi-regex/-/ansi-regex-3.0.0.tgz",
           "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
           "dev": true
         },
@@ -21104,7 +21104,7 @@
           "dependencies": {
             "strip-ansi": {
               "version": "4.0.0",
-              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+              "resolved": "https://uipath.pkgs.visualstudio.com/_packaging/npm-packages/npm/registry/strip-ansi/-/strip-ansi-4.0.0.tgz",
               "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
               "dev": true,
               "requires": {
@@ -21145,7 +21145,7 @@
         },
         "is-fullwidth-code-point": {
           "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+          "resolved": "https://uipath.pkgs.visualstudio.com/_packaging/npm-packages/npm/registry/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
           "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
           "dev": true
         },
@@ -21233,7 +21233,7 @@
           "dependencies": {
             "strip-ansi": {
               "version": "4.0.0",
-              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+              "resolved": "https://uipath.pkgs.visualstudio.com/_packaging/npm-packages/npm/registry/strip-ansi/-/strip-ansi-4.0.0.tgz",
               "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
               "dev": true,
               "requires": {
@@ -21250,7 +21250,7 @@
         },
         "which-module": {
           "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
+          "resolved": "https://uipath.pkgs.visualstudio.com/_packaging/npm-packages/npm/registry/which-module/-/which-module-2.0.0.tgz",
           "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
           "dev": true
         },
@@ -21367,7 +21367,7 @@
     },
     "when": {
       "version": "3.6.4",
-      "resolved": "https://registry.npmjs.org/when/-/when-3.6.4.tgz",
+      "resolved": "https://uipath.pkgs.visualstudio.com/_packaging/npm-packages/npm/registry/when/-/when-3.6.4.tgz",
       "integrity": "sha1-RztRfsFZ4rhQBUl6E5g/CVQS404=",
       "dev": true
     },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "angular-components",
-  "version": "9.0.2",
+  "version": "9.0.3",
   "author": {
     "name": "UiPath Inc",
     "url": "https://uipath.com"

--- a/projects/angular/components/ui-grid/src/ui-grid.component.html
+++ b/projects/angular/components/ui-grid/src/ui-grid.component.html
@@ -218,7 +218,7 @@
             <ng-container *ngIf="dataManager?.length; else noData">
                 <ng-container *ngIf="virtualScroll">
                     <cdk-virtual-scroll-viewport [total]="dataManager.length"
-                                                 autosize
+                                                 [itemSize]="rowSize"
                                                  uiVirtualScrollViewportResize
                                                  class="ui-grid-viewport">
                         <ng-container *cdkVirtualFor="let row of dataManager.data$ | async;

--- a/projects/angular/components/ui-grid/src/ui-grid.component.ts
+++ b/projects/angular/components/ui-grid/src/ui-grid.component.ts
@@ -229,6 +229,14 @@ export class UiGridComponent<T extends IGridDataEntry> extends ResizableGrid<T> 
     public showHeaderRow = true;
 
     /**
+     * Configure the row size for each row.
+     * TODO: Replace this with autosize when it comes out of cdk/experimental (scrolling issues on FF)
+     *
+     */
+    @Input()
+    public rowSize = 48;
+
+    /**
      * Emits an event with the sort model when a column sort changes.
      *
      */

--- a/projects/angular/components/ui-grid/src/ui-grid.module.ts
+++ b/projects/angular/components/ui-grid/src/ui-grid.module.ts
@@ -1,4 +1,3 @@
-import { ScrollingModule as XScrollingModule } from '@angular/cdk-experimental/scrolling';
 import { A11yModule } from '@angular/cdk/a11y';
 import { ScrollingModule } from '@angular/cdk/scrolling';
 import { CommonModule } from '@angular/common';
@@ -37,7 +36,6 @@ import { UiGridComponent } from './ui-grid.component';
         MatTooltipModule,
         MatProgressBarModule,
         ScrollingModule,
-        XScrollingModule,
         UiGridSearchModule,
         UiGridToggleColumnsModule,
         UiSuggestModule,

--- a/projects/angular/package.json
+++ b/projects/angular/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uipath/angular",
-  "version": "9.0.2",
+  "version": "9.0.3",
   "license": "MIT",
   "author": {
     "name": "UiPath Inc",
@@ -30,7 +30,6 @@
   "peerDependencies": {
     "@angular/animations": ">=8.0.0",
     "@angular/cdk": ">=8.0.0",
-    "@angular/cdk-experimental": ">=8.0.0",
     "@angular/common": ">=8.0.0",
     "@angular/compiler": ">=8.0.0",
     "@angular/core": ">=8.0.0",


### PR DESCRIPTION
Since ng 9 upgrade, on firefox, the cdk-virtual-scroll-viewport has scrolling issues (in our setup). If you scroll with the mouse wheel, it keeps doing translateY too early and resets the user position. If autosize is removed, this issue isn't reproduced anymore (there are still some small early translations in some conditions, but you can scroll to the bottom). 

We should use the autosize (cdk/experimental) when it's ready for production and out of experimental. Untill then you can pass the itemSize as an input prop.

- [ ]  Reproduce this bug in stackblitz and raise an issue on cdk. If I can't reproduce it, investigate our code more to see if I missed anything that causes this weird behaviour.