### PR TITLE
fix(secondformat): change behavior to average & ISO8601

### DIFF
--- a/projects/angular/directives/ui-secondformat/src/ui-secondformat.directive.spec.ts
+++ b/projects/angular/directives/ui-secondformat/src/ui-secondformat.directive.spec.ts
@@ -11,12 +11,14 @@ import { By } from '@angular/platform-browser';
 
 import * as moment from 'moment';
 import { BehaviorSubject } from 'rxjs';
+import { take } from 'rxjs/operators';
 
 import {
     ISecondFormatOptions,
     UI_SECONDFORMAT_OPTIONS,
     UiSecondFormatDirective,
 } from './ui-secondformat.directive';
+import { UiSecondFormatModule } from './ui-secondformat.module';
 
 @Component({
     selector: `ui-host-component`,
@@ -46,8 +48,10 @@ describe('Directive: UiSecondFormat', () => {
         moment.locale('en');
 
         TestBed.configureTestingModule({
+            imports: [
+                UiSecondFormatModule,
+            ],
             declarations: [
-                UiSecondFormatDirective,
                 TestHostComponent,
             ],
             providers: [
@@ -76,11 +80,11 @@ describe('Directive: UiSecondFormat', () => {
 
         const text = fixture.debugElement.query(By.directive(UiSecondFormatDirective));
 
-        expect(text.nativeElement.innerHTML.trim()).toBe('');
+        expect(text.nativeElement.innerText).toBe('');
     });
 
     describe('language: english', () => {
-        it('should return correctly display 2 days 3 hours 1 minutes 3 seconds', () => {
+        it('should return correctly display 2 days / PT51H1M3S', async () => {
             const days = 2 * DAY;
             const hours = 3 * HOUR;
             const minutes = 1 * MINUTE;
@@ -92,11 +96,13 @@ describe('Directive: UiSecondFormat', () => {
 
             const text = fixture.debugElement.query(By.directive(UiSecondFormatDirective));
 
-            expect(text.nativeElement.innerHTML.trim())
-                .toBe('2 days 3 hours a minute 3 seconds');
+            expect(text.nativeElement.innerText)
+                .toBe('2 days');
+            const tooltip = await component.uiSecondFormat.tooltip$.pipe(take(1)).toPromise();
+            expect(tooltip).toBe('PT51H1M3S');
         });
 
-        it('should return correctly display a day an hour a minute 1 seconds', () => {
+        it('should return correctly a day / PT25H1M1S', async () => {
             const days = DAY;
             const hours = HOUR;
             const minutes = MINUTE;
@@ -108,224 +114,44 @@ describe('Directive: UiSecondFormat', () => {
 
             const text = fixture.debugElement.query(By.directive(UiSecondFormatDirective));
 
-            expect(text.nativeElement.innerHTML.trim())
-                .toBe('a day an hour a minute 1 seconds');
+            expect(text.nativeElement.innerText)
+                .toBe('a day');
+            const tooltip = await component.uiSecondFormat.tooltip$.pipe(take(1)).toPromise();
+            expect(tooltip).toBe('PT25H1M1S');
         });
 
-        it('should display 0 seconds if the total amount of seconds is 0', () => {
+        it('should display a few seconds / P0D if the total amount of seconds is 0', async () => {
             component.seconds = 0;
 
             fixture.detectChanges();
 
             const text = fixture.debugElement.query(By.directive(UiSecondFormatDirective));
 
-            expect(text.nativeElement.innerHTML.trim())
-                .toBe('0 seconds');
-        });
-
-        Array(60).fill(0).map(() => Math.random())
-            .forEach((value, seconds) => {
-                it(`should display ${(seconds + value).toFixed(2)} seconds if the total amount of seconds is ${seconds + value}`, () => {
-                    component.seconds = seconds + value;
-
-                    fixture.detectChanges();
-
-                    const text = fixture.debugElement.query(By.directive(UiSecondFormatDirective));
-
-                    const expectedValue = (seconds + value).toFixed(2);
-
-                    expect(text.nativeElement.innerHTML.trim())
-                        .toBe(`${expectedValue} seconds`);
-                });
-            });
-
-        it('should NOT display 0 seconds if the total amount of seconds is 60', () => {
-            component.seconds = MINUTE;
-
-            fixture.detectChanges();
-
-            const text = fixture.debugElement.query(By.directive(UiSecondFormatDirective));
-
-            expect(text.nativeElement.innerHTML.trim())
-                .toBe('a minute');
-        });
-
-        it('should display a minute', () => {
-            component.seconds = MINUTE;
-
-            fixture.detectChanges();
-
-            const text = fixture.debugElement.query(By.directive(UiSecondFormatDirective));
-
-            expect(text.nativeElement.innerHTML.trim())
-                .toBe('a minute');
-        });
-
-        it('should display 3 minutes', () => {
-            component.seconds = 3 * MINUTE;
-
-            fixture.detectChanges();
-
-            const text = fixture.debugElement.query(By.directive(UiSecondFormatDirective));
-
-            expect(text.nativeElement.innerHTML.trim())
-                .toBe('3 minutes');
-        });
-
-        it('should display an hour', () => {
-            component.seconds = HOUR;
-
-            fixture.detectChanges();
-
-            const text = fixture.debugElement.query(By.directive(UiSecondFormatDirective));
-
-            expect(text.nativeElement.innerHTML.trim())
-                .toBe('an hour');
-        });
-
-        it('should display 3 hours', () => {
-            component.seconds = 3 * HOUR;
-
-            fixture.detectChanges();
-
-            const text = fixture.debugElement.query(By.directive(UiSecondFormatDirective));
-
-            expect(text.nativeElement.innerHTML.trim())
-                .toBe('3 hours');
-        });
-
-        it('should display a day', () => {
-            component.seconds = DAY;
-
-            fixture.detectChanges();
-
-            const text = fixture.debugElement.query(By.directive(UiSecondFormatDirective));
-
-            expect(text.nativeElement.innerHTML.trim())
-                .toBe('a day');
-        });
-
-        it('should display 2 days', () => {
-            component.seconds = 2 * DAY;
-
-            fixture.detectChanges();
-
-            const text = fixture.debugElement.query(By.directive(UiSecondFormatDirective));
-
-            expect(text.nativeElement.innerHTML.trim())
-                .toBe('2 days');
+            expect(text.nativeElement.innerText)
+                .toBe('a few seconds');
+            const tooltip = await component.uiSecondFormat.tooltip$.pipe(take(1)).toPromise();
+            expect(tooltip).toBe('P0D');
         });
     });
 
-    describe('language: japanese', () => {
-        beforeEach(() => {
+    describe('changing languages', () => {
+        it('should render the ja version after changing', async () => {
+            moment.locale('en');
+
+            component.seconds = 40;
+            fixture.detectChanges();
+
+            const text = fixture.debugElement.query(By.directive(UiSecondFormatDirective));
+            expect(text.nativeElement.innerText).toBe('a few seconds');
+            const enTooltip = await component.uiSecondFormat.tooltip$.pipe(take(1)).toPromise();
+
             moment.locale('ja');
-        });
-
-        Array(60).fill(0).map(() => Math.random())
-            .forEach((value, seconds) => {
-                it(`should display ${(seconds + value).toFixed(2)} seconds if the total amount of seconds is ${seconds + value}`, () => {
-                    component.seconds = seconds + value;
-
-                    fixture.detectChanges();
-
-                    const text = fixture.debugElement.query(By.directive(UiSecondFormatDirective));
-
-                    const expectedValue = (seconds + value).toFixed(2);
-
-                    expect(text.nativeElement.innerHTML.trim())
-                        .toBe(`${expectedValue}秒`);
-                });
-            });
-
-        it('should return correctly display 2 days 3 hours 1 minutes 3 seconds', () => {
-            const days = 2 * DAY;
-            const hours = 3 * HOUR;
-            const minutes = 1 * MINUTE;
-            const seconds = 3;
-
-            component.seconds = days + hours + minutes + seconds;
+            (options.redraw$ as BehaviorSubject<void>).next();
 
             fixture.detectChanges();
-
-            const text = fixture.debugElement.query(By.directive(UiSecondFormatDirective));
-
-            expect(text.nativeElement.innerHTML.trim())
-                .toBe('2日 3時間 1分 3秒');
-        });
-
-        it('should return correctly display a day an hour a minute 1 seconds', () => {
-            const days = DAY;
-            const hours = HOUR;
-            const minutes = MINUTE;
-            const seconds = 1;
-
-            component.seconds = days + hours + minutes + seconds;
-
-            fixture.detectChanges();
-
-            const text = fixture.debugElement.query(By.directive(UiSecondFormatDirective));
-
-            expect(text.nativeElement.innerHTML.trim())
-                .toBe('1日 1時間 1分 1秒');
-        });
-    });
-
-    describe('language: russian', () => {
-        beforeEach(() => {
-            moment.locale('ru');
-        });
-
-        Array(60).fill(0).map(() => Math.random())
-            .forEach((value, seconds) => {
-                it(`should display ${(seconds + value).toFixed(2)} seconds if the total amount of seconds is ${seconds + value}`, () => {
-                    component.seconds = seconds + value;
-
-                    fixture.detectChanges();
-
-                    const text = fixture.debugElement.query(By.directive(UiSecondFormatDirective));
-
-                    const expectedValue = (seconds + value).toFixed(2);
-
-                    expect(text.nativeElement.innerHTML.trim())
-                        .toBe(`${expectedValue} ${
-                            // why? because 🇷🇺 👾...
-                            [2, 3, 22, 23, 32, 33, 42, 43, 52, 53]
-                                .includes(seconds) ? 'секунды' : 'секунд'
-                        }`);
-                });
-            });
-
-        it('should return correctly display 2 days 3 hours 1 minutes 3 seconds', () => {
-            const days = 2 * DAY;
-            const hours = 3 * HOUR;
-            const minutes = 1 * MINUTE;
-            const seconds = 3;
-
-            component.seconds = days + hours + minutes + seconds;
-
-            fixture.detectChanges();
-
-            const text = fixture.debugElement.query(By.directive(UiSecondFormatDirective));
-
-            expect(text.nativeElement.innerHTML.trim())
-                .toBe('2 дня 3 часа 1 минута 3 секунды');
-        });
-
-        it('should return correctly display a day an hour a minute 1 seconds', () => {
-            const days = DAY;
-            const hours = HOUR;
-            const minutes = MINUTE;
-            const seconds = 1;
-
-            component.seconds = days + hours + minutes + seconds;
-
-            fixture.detectChanges();
-
-            const text = fixture.debugElement.query(By.directive(UiSecondFormatDirective));
-
-            expect(text.nativeElement.innerHTML.trim())
-                .toBe('день час 1 минута 1 секунда');
+            expect(text.nativeElement.innerText).toBe('数秒');
+            const jaTooltip = await component.uiSecondFormat.tooltip$.pipe(take(1)).toPromise();
+            expect(enTooltip).toBe(jaTooltip);
         });
     });
 });

--- a/projects/angular/directives/ui-secondformat/src/ui-secondformat.module.ts
+++ b/projects/angular/directives/ui-secondformat/src/ui-secondformat.module.ts
@@ -1,8 +1,11 @@
+import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
+import { MatTooltipModule } from '@angular/material/tooltip';
 
 import { UiSecondFormatDirective } from './ui-secondformat.directive';
 
 @NgModule({
+    imports: [CommonModule, MatTooltipModule],
     declarations: [UiSecondFormatDirective],
     exports: [UiSecondFormatDirective],
 })


### PR DESCRIPTION
it looks like the old implementation had a problem with languages other than English (e.g. German doesn't have 'mm' or 'hh' for relative times).
the new implementation uses moment's `duration()` with `humanize()` and a tooltip with `toIsoString()`

although the new implementation is a Component, it is backward compatible with the Directive and will be moved in its correct folder in v10.