### PR TITLE
fix(grid): default toggle disabled column

### DIFF
--- a/projects/angular/components/ui-grid/src/managers/visibility-manager.ts
+++ b/projects/angular/components/ui-grid/src/managers/visibility-manager.ts
@@ -106,9 +106,10 @@ export class VisibilityManger<T extends IGridDataEntry> {
 
             if (isDevMode()) {
                 console.warn(`Did not find column with [disableToggle]="true", locking '${firstColumn.property}' column`);
-                firstColumn!.disableToggle = true;
-                visibleOptions[0].disabled = true;
             }
+
+            firstColumn.disableToggle = true;
+            visibleOptions[0].disabled = true;
         }
 
         return columnOptions;


### PR DESCRIPTION
Production build were missing a key piece of functionality – disable toggling at least one column.
TBD how we avoid that in the future