### PR TITLE
feat(snackbar): add optional hardening when showing messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# v9.0.6 (2020-05-14)
+* **snackbar** enable configurable plain-text only messages (to help with XSS issues)
+
 # v9.0.5 (2020-04-07)
 * **drag-and-drop-file**: add multiple file types support
 * **grid**: fix default toggle disabled column

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "angular-components",
-  "version": "9.0.5",
+  "version": "9.0.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "angular-components",
-  "version": "9.0.5",
+  "version": "9.0.6",
   "author": {
     "name": "UiPath Inc",
     "url": "https://uipath.com"

--- a/projects/angular/components/ui-snackbar/src/public_api.ts
+++ b/projects/angular/components/ui-snackbar/src/public_api.ts
@@ -3,6 +3,8 @@ export {
     SnackbarAction,
     UiSnackBarService,
     UiSnackBarComponent,
+    UiMatSnackBarConfig,
+    UI_MAT_SNACK_BAR_DEFAULT_OPTIONS,
 } from './ui-snackbar.component';
 
 export { UiSnackBarModule } from './ui-snackbar.module';

--- a/projects/angular/components/ui-snackbar/src/ui-snackbar.component.spec.ts
+++ b/projects/angular/components/ui-snackbar/src/ui-snackbar.component.spec.ts
@@ -21,6 +21,8 @@ import {
     panelClass,
     SnackbarAction,
     SnackBarType,
+    UI_MAT_SNACK_BAR_DEFAULT_OPTIONS,
+    UiMatSnackBarConfig,
     UiSnackBarService,
 } from './ui-snackbar.component';
 import { UiSnackBarModule } from './ui-snackbar.module';
@@ -44,6 +46,7 @@ describe('Service: UiSnackBarService', () => {
     let service: UiSnackBarService;
     let overlayContainer: OverlayContainer;
     let fixture: ComponentFixture<SnackBarFixtureComponent>;
+    let securitySettings: UiMatSnackBarConfig;
 
     const getSnack = () =>
         overlayContainer
@@ -67,6 +70,10 @@ describe('Service: UiSnackBarService', () => {
     };
 
     beforeEach(async(() => {
+        securitySettings = {
+            restrictHtml: false,
+        };
+
         TestBed.configureTestingModule({
             imports: [
                 NoopAnimationsModule,
@@ -78,6 +85,10 @@ describe('Service: UiSnackBarService', () => {
                     useValue: {
                         duration: DEFAULT_DURATION,
                     },
+                },
+                {
+                    provide: UI_MAT_SNACK_BAR_DEFAULT_OPTIONS,
+                    useFactory: () => securitySettings,
                 },
             ],
             declarations: [
@@ -304,5 +315,22 @@ describe('Service: UiSnackBarService', () => {
         expect(snack).not.toBeNull();
         expect(snack.querySelectorAll('div.rich-class').length).toEqual(1);
         expect(snack.querySelectorAll('a').length).toEqual(1);
+    });
+
+    it('should REMOVE html from the message', () => {
+        securitySettings.restrictHtml = true;
+        fixture = TestBed.createComponent(SnackBarFixtureComponent);
+        service = fixture.componentInstance.service;
+
+        service.show(`
+            <a id="injected-link" href="#some-link">a link text</a>
+            <img id="injected-image" src="invalid" onerror=callError()>
+            hello world
+        `);
+
+        const snack = getSnack();
+
+        expect(snack!.querySelectorAll('a').length).toEqual(0, 'an anchor creeped into the message');
+        expect(snack!.querySelectorAll('img').length).toEqual(0, 'an img creeped into the message');
     });
 });

--- a/projects/angular/components/ui-snackbar/src/ui-snackbar.component.ts
+++ b/projects/angular/components/ui-snackbar/src/ui-snackbar.component.ts
@@ -3,6 +3,7 @@ import {
     Component,
     Inject,
     Injectable,
+    InjectionToken,
     Optional,
     TemplateRef,
     ViewEncapsulation,
@@ -79,6 +80,11 @@ export const ICON_MAP: Map<SnackBarType, string> = new Map([
 
 export type SnackbarAction = (message: string | TemplateRef<any>, duration?: number) => Observable<void>;
 
+export class UiMatSnackBarConfig {
+    public restrictHtml = false;
+}
+export const UI_MAT_SNACK_BAR_DEFAULT_OPTIONS = new InjectionToken<UiMatSnackBarConfig>('UiMatSnackBarConfig');
+
 /**
  * Snackbar config options
  */
@@ -129,6 +135,9 @@ export class UiSnackBarService {
         private _options: MatSnackBarConfig,
         @Optional()
         private readonly _snackIntl: UiSnackbarIntl,
+        @Inject(UI_MAT_SNACK_BAR_DEFAULT_OPTIONS)
+        @Optional()
+        private _additionalOptions?: UiMatSnackBarConfig,
     ) {
         this._snackIntl = this._snackIntl ||
             new UiSnackbarIntl();
@@ -169,6 +178,16 @@ export class UiSnackBarService {
         })
 
     private _alert(type: SnackBarType, options: ISnackBarAlert) {
+        if (
+            this._additionalOptions?.restrictHtml &&
+            typeof options.message === 'string'
+        ) {
+            const span = document.createElement('span');
+            span.innerText = options.message;
+            options.message = span.innerHTML;
+            span.remove();
+        }
+
         this._ref = this._snackBar.openFromComponent(UiSnackBarComponent, {
             data: {
                 closeAriaLabel: this._snackIntl.closeAriaLabel,

--- a/projects/angular/package.json
+++ b/projects/angular/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uipath/angular",
-  "version": "9.0.5",
+  "version": "9.0.6",
   "license": "MIT",
   "author": {
     "name": "UiPath Inc",


### PR DESCRIPTION
add support for injecting `UI_MAT_SNACK_BAR_DEFAULT_OPTIONS` which can enable `restrictHtml` - stripping the html tags and leaving only the text content in the shown message