### PR TITLE
fix(grid): multiple row selection with shift fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# v9.0.8 (2020-10-15)
+* **grid** fix multiple row selection with shift
+
 # v9.0.7 (2020-06-16)
 * **grid** fix a11y issue on toggle visibility column reset button
 * **a11y** add automatic aria-label support

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "angular-components",
-  "version": "9.0.7",
+  "version": "9.0.8",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "angular-components",
-  "version": "9.0.7",
+  "version": "9.0.8",
   "author": {
     "name": "UiPath Inc",
     "url": "https://uipath.com"

--- a/projects/angular/components/ui-grid/src/ui-grid.component.html
+++ b/projects/angular/components/ui-grid/src/ui-grid.component.html
@@ -286,7 +286,9 @@
              role="gridcell">
             <div *ngIf="selectable"
                  class="ui-grid-mobile-feature-container ui-grid-mobile-refresh-container">
-                <mat-checkbox (click)="$event.stopPropagation()"
+                <mat-checkbox (click)="checkShift($event)"
+                              (keyup.shift.space)="checkShift($event)"
+                              (keyup.space)="checkShift($event)"
                               (change)="handleSelection(index, row)"
                               [checked]="selectionManager.isSelected(row)"
                               [aria-label]="checkboxLabel(row)"
@@ -307,7 +309,9 @@
                     selectable"
              class="ui-grid-cell ui-grid-checkbox-cell ui-grid-feature-cell"
              role="gridcell">
-            <mat-checkbox (click)="$event.stopPropagation()"
+            <mat-checkbox (click)="checkShift($event)"
+                          (keyup.shift.space)="checkShift($event)"
+                          (keyup.space)="checkShift($event)"
                           (change)="handleSelection(index, row)"
                           [checked]="selectionManager.isSelected(row)"
                           [aria-label]="checkboxLabel(row)"

--- a/projects/angular/components/ui-grid/src/ui-grid.component.spec.ts
+++ b/projects/angular/components/ui-grid/src/ui-grid.component.spec.ts
@@ -467,6 +467,82 @@ describe('Component: UiGrid', () => {
                         expect(matCheckbox.checked).toEqual(false);
                     });
 
+                    it('should select all rows from 0 to the clicked one if shift is pressed', () => {
+                        const rowCheckboxInputList = fixture.debugElement
+                            .queryAll(By.css('.ui-grid-row .ui-grid-cell.ui-grid-checkbox-cell input'));
+
+                        const event = document.createEvent('MouseEvent');
+                        event.initMouseEvent('click', true, true, window, 0, 0, 0, 0, 0, false, false, true, false, 0, null);
+
+                        fixture.componentInstance.grid.checkShift(event);
+
+                        rowCheckboxInputList[10].nativeElement.dispatchEvent(EventGenerator.click);
+
+                        for (let i = 0; i <= 10; i ++) {
+                            expect(grid.selectionManager.isSelected(data[i])).toBeTrue();
+                        }
+                    });
+
+                    describe('Scenario: shift pressed after a row is selected by click without shift', () => {
+                        beforeEach(() => {
+                            const rowCheckboxInputList = fixture.debugElement
+                                .queryAll(By.css('.ui-grid-row .ui-grid-cell.ui-grid-checkbox-cell input'));
+
+                            rowCheckboxInputList[5].nativeElement.dispatchEvent(EventGenerator.click);
+
+                            const event = document.createEvent('MouseEvent');
+                            event.initMouseEvent('click', true, true, window, 0, 0, 0, 0, 0, false, false, true, false, 0, null);
+
+                            fixture.componentInstance.grid.checkShift(event);
+                        });
+
+                        it('should select rows between last clicked and current clicked when shift key is pressed', () => {
+                            const rowCheckboxInputList = fixture.debugElement
+                                .queryAll(By.css('.ui-grid-row .ui-grid-cell.ui-grid-checkbox-cell input'));
+
+                            rowCheckboxInputList[10].nativeElement.dispatchEvent(EventGenerator.click);
+
+                            fixture.detectChanges();
+
+                            for (let i = 5; i <= 10; i++) {
+                                expect(grid.selectionManager.isSelected(data[i])).toBeTrue();
+                            }
+                        });
+
+                        it('should not unselect row if clicked twice while shift pressed', () => {
+                            const rowCheckboxInputList = fixture.debugElement
+                                .queryAll(By.css('.ui-grid-row .ui-grid-cell.ui-grid-checkbox-cell input'));
+
+                            rowCheckboxInputList[5].nativeElement.dispatchEvent(EventGenerator.click);
+
+                            fixture.detectChanges();
+
+                            expect(grid.selectionManager.isSelected(data[5])).toBeTrue();
+                        });
+
+                        it('should correctly deselect and select on range change while shift pressed', () => {
+                            const rowCheckboxInputList = fixture.debugElement
+                                .queryAll(By.css('.ui-grid-row .ui-grid-cell.ui-grid-checkbox-cell input'));
+
+                            rowCheckboxInputList[10].nativeElement.dispatchEvent(EventGenerator.click);
+                            fixture.detectChanges();
+
+                            for (let i = 5; i <= 10; i++) {
+                                expect(grid.selectionManager.isSelected(data[i])).toBeTrue();
+                            }
+
+                            rowCheckboxInputList[2].nativeElement.dispatchEvent(EventGenerator.click);
+                            fixture.detectChanges();
+
+                            for (let i = 2; i <= 5; i++) {
+                                expect(grid.selectionManager.isSelected(data[i])).toBeTrue();
+                            }
+                            for (let i = 6; i <= 10; i++) {
+                                expect(grid.selectionManager.isSelected(data[i])).toBeFalse();
+                            }
+                        });
+                    });
+
                     it('should NOT show multi page select info message if multiPageSelect is false and selection is made', () => {
                         grid.multiPageSelect = false;
                         const rowCheckboxInputList = fixture.debugElement

--- a/projects/angular/package.json
+++ b/projects/angular/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uipath/angular",
-  "version": "9.0.7",
+  "version": "9.0.8",
   "license": "MIT",
   "author": {
     "name": "UiPath Inc",


### PR DESCRIPTION
When shift key is used while multi selecting, the checkbox appeared as unselected even though in the model it was selected.
Performance improvements for shift selection algorithm (instead of deselecting everything and selecting again, we calculate the rows to be selected and the rows to be deselected excepting the ones that already are in correct state).
