### PR TITLE
fix(a11y): grid announce

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+# v9.1.0 (2020-10-21)
+* **grid** differentiate between user sort and programmatic sort events
+* **grid** a11y: announce only user `sort` events
+* **grid** a11y: expose translateable aria-label for checkboxes
+* **grid** added `matTooltip` for checkboxes
+* **suggest** a11y: fixes to title, specify `role` attributes for list
+* **suggest** a11y: announce current `option` on open
+
 # v9.0.8 (2020-10-15)
 * **grid** fix multiple row selection with shift
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "angular-components",
-  "version": "9.0.8",
+  "version": "9.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "angular-components",
-  "version": "9.0.8",
+  "version": "9.1.0",
   "author": {
     "name": "UiPath Inc",
     "url": "https://uipath.com"

--- a/projects/angular/components/ui-grid/src/components/ui-grid-search/ui-grid-search.component.html
+++ b/projects/angular/components/ui-grid/src/components/ui-grid-search/ui-grid-search.component.html
@@ -31,7 +31,6 @@
        <mat-icon *ngIf="!search.value"
                  [matTooltip]="searchTooltip"
                  [matTooltipDisabled]="tooltipDisabled"
-                 svgIcon="uipath:search"
                  matSuffix
                  class="svg-icon">
               <svg width="100%"

--- a/projects/angular/components/ui-grid/src/managers/sort-manager.spec.ts
+++ b/projects/angular/components/ui-grid/src/managers/sort-manager.spec.ts
@@ -52,7 +52,19 @@ describe('Component: UiGrid', () => {
                 expect(manager.columns).toBe(columns);
             });
 
-            describe('Event: sort change', () => {
+            it('should update sort event if columns change', () => {
+                const cols = generateColumnList('random');
+                cols.forEach(column => {
+                    column.sortable = true;
+                    column.sort = 'asc';
+                });
+
+                manager.columns = cols;
+                expect(Object.keys(manager.sort$.getValue()).length).toBe(4);
+                expect(manager.sort$.getValue().userEvent).toBeFalse();
+            });
+
+            describe('Event: user sort change', () => {
                 it(`should cycle column sort from '' to 'asc'`, () => {
                     const column = faker.helpers.randomize(columns);
                     column.sort = '';
@@ -110,6 +122,7 @@ describe('Component: UiGrid', () => {
                         ).subscribe(sort => {
                             expect(sort.field).toEqual(column.property!);
                             expect(sort.direction).toEqual(column.sort);
+                            expect(sort.userEvent).toBeTrue();
                         });
 
                     manager.changeSort(column);
@@ -129,6 +142,7 @@ describe('Component: UiGrid', () => {
                         ).subscribe(sort => {
                             expect(sort.field).toEqual(first.property!);
                             expect(sort.direction).toEqual(first.sort);
+                            expect(sort.userEvent).toBeTrue();
                         });
 
                     manager.sort$
@@ -139,6 +153,7 @@ describe('Component: UiGrid', () => {
                         ).subscribe(sort => {
                             expect(sort.field).toEqual(second.property!);
                             expect(sort.direction).toEqual(second.sort);
+                            expect(sort.userEvent).toBeTrue();
                         });
 
                     manager.changeSort(first);

--- a/projects/angular/components/ui-grid/src/managers/sort-manager.ts
+++ b/projects/angular/components/ui-grid/src/managers/sort-manager.ts
@@ -48,7 +48,9 @@ export class SortManager<T> {
 
         this._emitSort(sortedColumn);
     }
-
+    /**
+     * Sort based on user action on column header
+     */
     public changeSort(column: UiGridColumnDirective<T>) {
         if (!column.sortable) { return; }
 
@@ -58,18 +60,19 @@ export class SortManager<T> {
 
         column.sort = SORT_CYCLE_MAP[column.sort];
 
-        this._emitSort(column);
+        this._emitSort(column, true);
     }
 
     public destroy() {
         this.sort$.complete();
     }
 
-    private _emitSort(column: UiGridColumnDirective<T>) {
+    private _emitSort(column: UiGridColumnDirective<T>, userEvent = false) {
         const updatedSort = {
             direction: column.sort,
             field: column.property,
             title: column.title,
+            userEvent,
         } as ISortModel<T>;
 
         if (isEqual(this.sort$.getValue(), updatedSort)) { return; }

--- a/projects/angular/components/ui-grid/src/models/sortModel.ts
+++ b/projects/angular/components/ui-grid/src/models/sortModel.ts
@@ -21,4 +21,9 @@ export interface ISortModel<T> {
      *
      */
     title: string;
+    /**
+     * Sort event as a result of direct user intent to sort by a column.
+     *
+     */
+    userEvent?: boolean;
 }

--- a/projects/angular/components/ui-grid/src/ui-grid.component.html
+++ b/projects/angular/components/ui-grid/src/ui-grid.component.html
@@ -172,7 +172,6 @@
                         </div>
 
                         <div *ngIf="column.resizeable && !last"
-                             [class.is-resizing]="column.isResizing"
                              (mousedown)="resizeManager.startResize($event, column)"
                              class="ui-grid-resize-anchor">
                             <mat-icon>

--- a/projects/angular/components/ui-grid/src/ui-grid.component.html
+++ b/projects/angular/components/ui-grid/src/ui-grid.component.html
@@ -126,7 +126,8 @@
                                       [disabled]="!dataManager.length"
                                       [checked]="isEveryVisibleRowChecked"
                                       [indeterminate]="hasValueOnVisiblePage && !isEveryVisibleRowChecked"
-                                      [aria-label]="checkboxLabel()"
+                                      [matTooltip]="checkboxTooltip()"
+                                      [aria-label]="checkboxTooltip()"
                                       tabindex="0">
                         </mat-checkbox>
                     </div>
@@ -290,7 +291,8 @@
                               (keyup.space)="checkShift($event)"
                               (change)="handleSelection(index, row)"
                               [checked]="selectionManager.isSelected(row)"
-                              [aria-label]="checkboxLabel(row)"
+                              [matTooltip]="checkboxTooltip(row)"
+                              [aria-label]="checkboxTooltip(row)"
                               tabindex="0">
                 </mat-checkbox>
             </div>
@@ -313,7 +315,8 @@
                           (keyup.space)="checkShift($event)"
                           (change)="handleSelection(index, row)"
                           [checked]="selectionManager.isSelected(row)"
-                          [aria-label]="checkboxLabel(row)"
+                          [matTooltip]="checkboxTooltip(row)"
+                          [aria-label]="checkboxTooltip(row)"
                           tabindex="0">
             </mat-checkbox>
         </div>

--- a/projects/angular/components/ui-grid/src/ui-grid.component.spec.ts
+++ b/projects/angular/components/ui-grid/src/ui-grid.component.spec.ts
@@ -345,15 +345,33 @@ describe('Component: UiGrid', () => {
                 });
 
                 describe('Feature: checkbox', () => {
-                    it('should check all rows if the header checkbox is clicked', () => {
+                    it('should have ariaLabel set correctly for toggle selection', () => {
                         const checkboxHeader = fixture.debugElement.query(By.css('.ui-grid-header-cell.ui-grid-checkbox-cell'));
+                        const matCheckbox = checkboxHeader.query(By.css('mat-checkbox')).componentInstance as MatCheckbox;
+
+                        expect(matCheckbox.checked).toEqual(false);
+                        expect(matCheckbox.ariaLabel).toEqual('Select all');
 
                         const checkboxInput = checkboxHeader.query(By.css('input'));
                         checkboxInput.nativeElement.dispatchEvent(EventGenerator.click);
 
                         fixture.detectChanges();
 
+
+                        expect(matCheckbox.checked).toEqual(true);
+                        expect(matCheckbox.ariaLabel).toEqual('Deselect all');
+                    });
+
+                    it('should check all rows if the header checkbox is clicked', () => {
+                        const checkboxHeader = fixture.debugElement.query(By.css('.ui-grid-header-cell.ui-grid-checkbox-cell'));
                         const matCheckbox = checkboxHeader.query(By.css('mat-checkbox')).componentInstance as MatCheckbox;
+
+                        expect(matCheckbox.checked).toEqual(false);
+
+                        const checkboxInput = checkboxHeader.query(By.css('input'));
+                        checkboxInput.nativeElement.dispatchEvent(EventGenerator.click);
+
+                        fixture.detectChanges();
 
                         expect(matCheckbox.checked).toEqual(true);
 
@@ -388,7 +406,10 @@ describe('Component: UiGrid', () => {
 
                         expect(rowCheckboxList.length).toEqual(data.length);
 
-                        rowCheckboxList.forEach(checkbox => expect(checkbox.checked).toEqual(true));
+                        rowCheckboxList.forEach((checkbox, i) => {
+                            expect(checkbox.checked).toEqual(true);
+                            expect(checkbox.ariaLabel).toEqual(`Deselect row ${i}`);
+                        });
 
                         expect(grid.selectionManager.selected.length).toEqual(data.length);
                         expect(grid.selectionManager.selected).toEqual(data);
@@ -398,7 +419,10 @@ describe('Component: UiGrid', () => {
                         fixture.detectChanges();
 
                         expect(matCheckbox.checked).toEqual(false);
-                        rowCheckboxList.forEach(checkbox => expect(checkbox.checked).toEqual(false));
+                        rowCheckboxList.forEach((checkbox, i) => {
+                             expect(checkbox.checked).toEqual(false);
+                             expect(checkbox.ariaLabel).toEqual(`Select row ${i}`);
+                        });
                         expect(grid.hasValueOnVisiblePage).toEqual(false);
                     });
 
@@ -478,7 +502,7 @@ describe('Component: UiGrid', () => {
 
                         rowCheckboxInputList[10].nativeElement.dispatchEvent(EventGenerator.click);
 
-                        for (let i = 0; i <= 10; i ++) {
+                        for (let i = 0; i <= 10; i++) {
                             expect(grid.selectionManager.isSelected(data[i])).toBeTrue();
                         }
                     });

--- a/projects/angular/components/ui-grid/src/ui-grid.component.ts
+++ b/projects/angular/components/ui-grid/src/ui-grid.component.ts
@@ -112,7 +112,7 @@ export class UiGridComponent<T extends IGridDataEntry> extends ResizableGrid<T> 
      *
      */
     public get isEveryVisibleRowChecked() {
-        return this.dataManager.length &&
+        return !!this.dataManager.length &&
             this.dataManager.every(row => this.selectionManager.isSelected(row!));
     }
 
@@ -638,8 +638,21 @@ export class UiGridComponent<T extends IGridDataEntry> extends ResizableGrid<T> 
     }
 
     /**
-     * Determines the `checkbox` `aria-label`.
+     * Determines the `checkbox` `matToolTip`.
      *
+     * @param [row] The row for which the label is computed.
+     */
+    public checkboxTooltip(row?: T): string {
+        if (!row) {
+            return this.intl.checkboxTooltip(this.isEveryVisibleRowChecked);
+        }
+
+        return this.intl.checkboxTooltip(this.selectionManager.isSelected(row), this.dataManager.indexOf(row));
+    }
+
+    /**
+     * Determines the `checkbox` aria-label`.
+     * **DEPRECATED**
      * @param [row] The row for which the label is computed.
      */
     public checkboxLabel(row?: T): string {

--- a/projects/angular/components/ui-grid/src/ui-grid.component.ts
+++ b/projects/angular/components/ui-grid/src/ui-grid.component.ts
@@ -32,9 +32,9 @@ import {
 import {
     debounceTime,
     distinctUntilChanged,
+    filter,
     map,
     observeOn,
-    skip,
     switchMap,
     take,
     takeUntil,
@@ -497,7 +497,9 @@ export class UiGridComponent<T extends IGridDataEntry> extends ResizableGrid<T> 
             msg => this._queuedAnnouncer.enqueue(msg),
             this.intl,
             this.dataManager.data$,
-            this.sortManager.sort$.pipe(skip(1)),
+            this.sortManager.sort$.pipe(
+                filter(({ userEvent }) => !!userEvent),
+            ),
             this.refresh,
             this.footer && this.footer.pageChange,
         );

--- a/projects/angular/components/ui-grid/src/ui-grid.intl.ts
+++ b/projects/angular/components/ui-grid/src/ui-grid.intl.ts
@@ -99,6 +99,18 @@ export class UiGridIntl implements OnDestroy {
      */
     public descending = 'descending';
 
+    /**
+     * Determines the `checkbox` `matToolTip`.
+     *
+     * @param [rowIndex] The rowIndex for which the label is computed.
+     */
+    public checkboxTooltip(selected: boolean, rowIndex?: number): string {
+        if (rowIndex == null) {
+            return `${selected ? 'Deselect' : 'Select'} all`;
+        }
+        return `${selected ? 'Deselect' : 'Select'} row ${rowIndex}`;
+    }
+
 
     /**
      * Generates a selection label for the given count.

--- a/projects/angular/package.json
+++ b/projects/angular/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uipath/angular",
-  "version": "9.0.8",
+  "version": "9.1.0",
   "license": "MIT",
   "author": {
     "name": "UiPath Inc",


### PR DESCRIPTION
- [x] feat(**grid**) differentiate between user sort and programmatic sort events
- [x] fix(**grid**) a11y: announce only user `sort` events
- [x] fix(**grid**) a11y: translatable aria-labels for checkboxes 
- [x] merge #106 
