### PR TITLE
Feat/expose grid cache option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# v11.0.0-rc.2 (2020-11-25)
+* **BREAKING CHANGE** grid no longer uses cache for IE by default
+
 # v11.0.0-rc.1 (2020-11-12)
 * **BREAKING CHANGE** Upgrade to Angular 11
 * **snackbar** expose action button

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "angular-components",
-  "version": "11.0.0-rc.1",
+  "version": "11.0.0-rc.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "angular-components",
-  "version": "11.0.0-rc.1",
+  "version": "11.0.0-rc.2",
   "author": {
     "name": "UiPath Inc",
     "url": "https://uipath.com"

--- a/projects/angular/components/ui-grid/src/managers/data-manager.spec.ts
+++ b/projects/angular/components/ui-grid/src/managers/data-manager.spec.ts
@@ -13,248 +13,271 @@ import { DataManager } from './data-manager';
 describe('Component: UiGrid', () => {
     const generateEntityList = generateListFactory(generateEntity);
 
-    describe('Manager: DataManager', () => {
-        let manager: DataManager<ITestEntity>;
-
-        beforeEach(() => {
-            manager = new DataManager<ITestEntity>();
+    describe('Defaults', () => {
+        it('should have correct defaults', () => {
+            const mgr = new DataManager<ITestEntity>();
+            expect(mgr.useCache).toBe(false);
+            expect(mgr.idProperty).toBe('id');
         });
+    });
 
-        describe('State: initial', () => {
-            it('should have a length of 0', () => {
-                expect(manager.length).toEqual(0);
-            });
-
-            it('should be pristine', () => {
-                expect(manager.pristine).toEqual(true);
-            });
-
-            it('should expose a behavior subject data stream', () => {
-                expect(manager.data$).toBeDefined();
-                expect(manager.data$.constructor).toBe(BehaviorSubject);
-            });
-
-            it('should expose a data stream with initial value an empty array', () => {
-                const initialValue = manager.data$.getValue();
-                expect(isArray(initialValue)).toBe(true);
-                expect(initialValue.length).toBe(0);
-            });
-        });
-
-        describe('State: with data', () => {
-            let data: ITestEntity[];
+    [
+        { useCache: true, idProperty: 'id' as const },
+        { useCache: false, idProperty: 'id' as const },
+    ].forEach((config) => {
+        describe(`Manager: DataManager, useCache: ${config.useCache}, idProperty: ${config.idProperty}`, () => {
+            let manager: DataManager<ITestEntity>;
 
             beforeEach(() => {
-                data = generateEntityList('random');
-                manager.update(data);
+                manager = new DataManager<ITestEntity>(config);
             });
 
-            it('should NOT be pristine', () => {
-                expect(manager.pristine).toEqual(false);
+            describe('State: initial', () => {
+                it('should have a length of 0', () => {
+                    expect(manager.length).toEqual(0);
+                });
+
+                it('should be pristine', () => {
+                    expect(manager.pristine).toEqual(true);
+                });
+
+                it('should expose a behavior subject data stream', () => {
+                    expect(manager.data$).toBeDefined();
+                    expect(manager.data$.constructor).toBe(BehaviorSubject);
+                });
+
+                it('should expose a data stream with initial value an empty array', () => {
+                    const initialValue = manager.data$.getValue();
+                    expect(isArray(initialValue)).toBe(true);
+                    expect(initialValue.length).toBe(0);
+                });
             });
 
-            describe('Method: update', () => {
-                it(`should NOT preserve list or item reference`, () => {
-                    const managerList = manager.data$.getValue();
+            describe('State: with data', () => {
+                let data: ITestEntity[];
 
-                    expect(managerList).not.toBe(data);
+                beforeEach(() => {
+                    data = generateEntityList('random');
+                    manager.update(data);
+                });
 
-                    manager.forEach((managerEntry, idx) => {
-                        const entry = data[idx];
-                        expect(managerEntry).not.toBe(entry);
-                        expect(managerEntry!.myObj).not.toBe(entry.myObj);
+                it('should NOT be pristine', () => {
+                    expect(manager.pristine).toEqual(false);
+                });
+
+                describe('Method: update', () => {
+                    it(`should NOT preserve list or item reference`, () => {
+                        const managerList = manager.data$.getValue();
+
+                        expect(managerList).not.toBe(data);
+
+                        manager.forEach((managerEntry, idx) => {
+                            const entry = data[idx];
+                            expect(managerEntry).not.toBe(entry);
+                            expect(managerEntry!.myObj).not.toBe(entry.myObj);
+                        });
+                    });
+
+                    it(`should have length equal to the new data list`, () => {
+                        expect(manager.length).toEqual(data.length);
+                    });
+
+                    it('should have the same entry on the same indexes', () => {
+                        const managerList = manager.data$.getValue();
+
+                        expect(managerList).toEqual(data);
+
+                        data.forEach((entry, idx) => {
+                            const managerEntry = manager.get(idx);
+                            expect(managerEntry).toEqual(entry);
+                        });
+                    });
+
+                    it('should update the internal array reference on subsequent updates', () => {
+                        const firstEntity = manager.get(0);
+                        const firstEntityClone = cloneDeep(firstEntity);
+
+                        const update = generateEntityList(manager.length);
+
+                        manager.update(update);
+
+                        const firstEntityUpdated = manager.get(0);
+
+                        expect(firstEntityClone).not.toEqual(firstEntityUpdated);
+
+                        if (manager.useCache) {
+                            expect(firstEntity).toBe(firstEntityUpdated);
+                        } else {
+                            expect(update[0]).toEqual(firstEntityUpdated);
+                        }
+                    });
+
+                    it('should emit new data when on update', (done) => {
+                        const update = generateEntityList(3);
+
+                        manager.data$
+                            .pipe(skip(1))
+                            .subscribe((event) => {
+                                expect(event).not.toBe(update);
+                                expect(event).toEqual(update);
+
+                                done();
+                            });
+
+                        manager.update(update);
                     });
                 });
 
-                it(`should have length equal to the new data list`, () => {
-                    expect(manager.length).toEqual(data.length);
-                });
+                describe('Method: patchRow', () => {
+                    it('should update specified properties', () => {
+                        const first = manager.get(0);
 
-                it('should have the same entry on the same indexes', () => {
-                    const managerList = manager.data$.getValue();
+                        const patch: Partial<ITestEntity> = {
+                            myBool: false,
+                            myDate: new Date(),
+                        };
 
-                    expect(managerList).toEqual(data);
+                        manager.patchRow(first.id, patch);
 
-                    data.forEach((entry, idx) => {
-                        const managerEntry = manager.get(idx);
-                        expect(managerEntry).toEqual(entry);
+                        expect(first.myBool).toEqual(patch.myBool!);
+                        expect(first.myDate).toEqual(patch.myDate!);
+                    });
+
+                    it('should emit new data when an entry is patched', (done) => {
+                        const middle = manager.get(Math.floor(manager.length / 2));
+
+                        const patch: Partial<ITestEntity> = {
+                            myBool: false,
+                            myDate: new Date(),
+                        };
+
+                        manager.data$
+                            .pipe(skip(1))
+                            .subscribe(event => {
+                                const emittedEntry = event.find(x => x.id === middle.id);
+
+                                expect(middle.myBool).toEqual(patch.myBool!);
+                                expect(middle.myDate).toEqual(patch.myDate!);
+                                if (manager.useCache) {
+                                    expect(emittedEntry).toBe(middle);
+                                }
+                                expect(emittedEntry).toEqual(middle);
+
+                                done();
+                            });
+
+                        manager.patchRow(middle.id, patch);
+                    });
+
+                    it('should update NESTED properties', () => {
+                        const first = manager.get(0);
+
+                        const patch = {
+                            myObj: {
+                                myObjNumber: -123,
+                                myObjString: 'XYZ',
+                            },
+                        } as Partial<ITestEntity>;
+
+                        manager.patchRow(first.id, patch);
+
+                        expect(first.myObj.myObjNumber).toEqual(patch.myObj!.myObjNumber);
+                        expect(first.myObj.myObjString).toEqual(patch.myObj!.myObjString);
+                    });
+
+                    it('should update the hashed value for the affected entry', () => {
+                        if (!manager.useCache) {
+                            return;
+                        }
+
+                        const first = manager.get(0);
+                        const initialHash = manager.hashTrack(null, first);
+
+                        const patch: Partial<ITestEntity> = {
+                            myBool: false,
+                            myDate: new Date(),
+                        };
+
+                        manager.patchRow(first.id, patch);
+                        expect(manager.hashTrack(null, first)).not.toBe(initialHash);
                     });
                 });
 
-                it('should update the internal array reference on subsequent updates', () => {
-                    const firstEntity = manager.get(0);
-                    const firstEntityClone = cloneDeep(firstEntity);
+                describe('Method: find', () => {
+                    it('should be able fetch the FIRST entry by id', () => {
+                        const [first] = manager.data$.getValue();
 
-                    const update = generateEntityList(manager.length);
+                        const found = manager.find(first.id);
 
-                    manager.update(update);
+                        expect(found).toEqual(first);
+                        expect(found).toBe(first);
+                    });
 
-                    const firstEntityUpdated = manager.get(0);
+                    it('should be able fetch the LAST entry by id', () => {
+                        const [last] = manager.data$.getValue().slice().reverse();
 
-                    expect(firstEntityClone).not.toEqual(firstEntityUpdated);
+                        const found = manager.find(last.id);
 
-                    expect(firstEntity).toBe(firstEntityUpdated);
-                    expect(firstEntity).toEqual(firstEntityUpdated);
+                        expect(found).toEqual(last);
+                        expect(found).toBe(last);
+                    });
                 });
 
-                it('should emit new data when on update', (done) => {
-                    const update = generateEntityList(3);
+                describe('Method: get', () => {
+                    it('should be able fetch the FIRST entry by index', () => {
+                        const [first] = manager.data$.getValue();
 
-                    manager.data$
-                        .pipe(skip(1))
-                        .subscribe((event) => {
-                            expect(event).not.toBe(update);
-                            expect(event).toEqual(update);
+                        const found = manager.get(0);
 
-                            done();
+                        expect(found).toEqual(first);
+                        expect(found).toBe(first);
+                    });
+
+                    it('should be able fetch the LAST entry by index', () => {
+                        const [last] = manager.data$.getValue().slice().reverse();
+
+                        const found = manager.get(manager.length - 1);
+
+                        expect(found).toEqual(last);
+                        expect(found).toBe(last);
+                    });
+                });
+
+                describe('Method: forEach', () => {
+                    it('should itterate through all entries', () => {
+                        const managerList = manager.data$.getValue();
+
+                        let itterated = 0;
+
+                        manager.forEach((entry, idx) => {
+                            expect(entry).toEqual(managerList[idx]);
+                            itterated++;
                         });
 
-                    manager.update(update);
-                });
-            });
-
-            describe('Method: patchRow', () => {
-                it('should update specified properties', () => {
-                    const first = manager.get(0);
-
-                    const patch: Partial<ITestEntity> = {
-                        myBool: false,
-                        myDate: new Date(),
-                    };
-
-                    manager.patchRow(first.id, patch);
-
-                    expect(first.myBool).toEqual(patch.myBool!);
-                    expect(first.myDate).toEqual(patch.myDate!);
-                });
-
-                it('should emit new data when an entry is patched', (done) => {
-                    const middle = manager.get(Math.floor(manager.length / 2));
-
-                    const patch: Partial<ITestEntity> = {
-                        myBool: false,
-                        myDate: new Date(),
-                    };
-
-                    manager.data$
-                        .pipe(skip(1))
-                        .subscribe(event => {
-                            const emittedEntry = event.find(x => x.id === middle.id);
-
-                            expect(middle.myBool).toEqual(patch.myBool!);
-                            expect(middle.myDate).toEqual(patch.myDate!);
-                            expect(emittedEntry).toBe(middle);
-
-                            done();
-                        });
-
-                    manager.patchRow(middle.id, patch);
-                });
-
-                it('should update NESTED properties', () => {
-                    const first = manager.get(0);
-
-                    const patch = {
-                        myObj: {
-                            myObjNumber: -123,
-                            myObjString: 'XYZ',
-                        },
-                    } as Partial<ITestEntity>;
-
-                    manager.patchRow(first.id, patch);
-
-                    expect(first.myObj.myObjNumber).toEqual(patch.myObj!.myObjNumber);
-                    expect(first.myObj.myObjString).toEqual(patch.myObj!.myObjString);
-                });
-
-                it('should update the hashed value for the affected entry', () => {
-                    const first = manager.get(0);
-                    const initialHash = manager.hashTrack(null, first);
-
-                    const patch: Partial<ITestEntity> = {
-                        myBool: false,
-                        myDate: new Date(),
-                    };
-
-                    manager.patchRow(first.id, patch);
-                    expect(manager.hashTrack(null, first)).not.toBe(initialHash);
-                });
-            });
-
-            describe('Method: find', () => {
-                it('should be able fetch the FIRST entry by id', () => {
-                    const [first] = manager.data$.getValue();
-
-                    const found = manager.find(first.id);
-
-                    expect(found).toEqual(first);
-                    expect(found).toBe(first);
-                });
-
-                it('should be able fetch the LAST entry by id', () => {
-                    const [last] = manager.data$.getValue().slice().reverse();
-
-                    const found = manager.find(last.id);
-
-                    expect(found).toEqual(last);
-                    expect(found).toBe(last);
-                });
-            });
-
-            describe('Method: get', () => {
-                it('should be able fetch the FIRST entry by index', () => {
-                    const [first] = manager.data$.getValue();
-
-                    const found = manager.get(0);
-
-                    expect(found).toEqual(first);
-                    expect(found).toBe(first);
-                });
-
-                it('should be able fetch the LAST entry by index', () => {
-                    const [last] = manager.data$.getValue().slice().reverse();
-
-                    const found = manager.get(manager.length - 1);
-
-                    expect(found).toEqual(last);
-                    expect(found).toBe(last);
-                });
-            });
-
-            describe('Method: forEach', () => {
-                it('should itterate through all entries', () => {
-                    const managerList = manager.data$.getValue();
-
-                    let itterated = 0;
-
-                    manager.forEach((entry, idx) => {
-                        expect(entry).toEqual(managerList[idx]);
-                        itterated++;
+                        expect(itterated).toEqual(manager.length);
                     });
-
-                    expect(itterated).toEqual(manager.length);
                 });
-            });
 
-            describe('Method: every', () => {
-                it('should yield the same result as if applied to the array directly', () => {
-                    const managerList = manager.data$.getValue();
+                describe('Method: every', () => {
+                    it('should yield the same result as if applied to the array directly', () => {
+                        const managerList = manager.data$.getValue();
 
-                    const listResult = managerList.every(e => e!.myBool);
-                    const managerResult = manager.every(e => e!.myBool);
+                        const listResult = managerList.every(e => e!.myBool);
+                        const managerResult = manager.every(e => e!.myBool);
 
-                    expect(listResult).toEqual(managerResult);
+                        expect(listResult).toEqual(managerResult);
+                    });
                 });
-            });
 
-            describe('Method: some', () => {
-                it('should yield the same result as if applied to the array directly', () => {
-                    const managerList = manager.data$.getValue();
+                describe('Method: some', () => {
+                    it('should yield the same result as if applied to the array directly', () => {
+                        const managerList = manager.data$.getValue();
 
-                    const listResult = managerList.some(e => e!.myBool);
-                    const managerResult = manager.some(e => e!.myBool);
+                        const listResult = managerList.some(e => e!.myBool);
+                        const managerResult = manager.some(e => e!.myBool);
 
-                    expect(listResult).toEqual(managerResult);
+                        expect(listResult).toEqual(managerResult);
+                    });
                 });
             });
         });

--- a/projects/angular/components/ui-grid/src/managers/data-manager.ts
+++ b/projects/angular/components/ui-grid/src/managers/data-manager.ts
@@ -32,9 +32,16 @@ const customPatch = (left: any, right: any): any => {
  */
 type PropertyMap<T> = { [Key in keyof T]?: PropertyMap<T[Key]> };
 
+export interface DataManagerOptions<T> {
+    useCache?: boolean;
+    idProperty?: keyof T;
+}
+
+type StringOrNumberKeyOf<T> = keyof T & (string | number);
+
 /**
  * The data manager increases rendering performance drastically updating the dataset.
- * By updating the references directly:
+ * By updating the references directly (when having set useCache: true – default: false)
  * * the renderer will update the invidivual cells rather than redraw the entire row
  * * increasing / decreasing data count will result in less node insertion / removal
  *
@@ -42,9 +49,18 @@ type PropertyMap<T> = { [Key in keyof T]?: PropertyMap<T[Key]> };
  * @ignore
  * @internal
  */
-export class DataManager<T extends IGridDataEntry> {
+export class DataManager<T extends IGridDataEntry, K extends StringOrNumberKeyOf<T> = StringOrNumberKeyOf<T>> {
+
+    public useCache: boolean;
+    public idProperty: K;
+
     public get length() {
         return this.data$.value.length;
+    }
+
+    constructor(options?: DataManagerOptions<T>) {
+        this.useCache = options?.useCache ?? false;
+        this.idProperty = options?.idProperty as unknown as K ?? 'id';
     }
 
     public pristine = true;
@@ -53,7 +69,7 @@ export class DataManager<T extends IGridDataEntry> {
 
     public getProperty = get;
 
-    private _hashMap = new Map<number | string, string>();
+    private _hashMap = new Map<string, string>();
 
     public forEach = (callbackfn: (value: T, index: number, array: T[]) => void) =>
         this.data$.value.forEach(callbackfn)
@@ -68,19 +84,29 @@ export class DataManager<T extends IGridDataEntry> {
         return this.data$.value.indexOf(entry);
     }
 
-    public find = (entryId: number | string) =>
-        this.data$.value.find(e => e.id === entryId)
+    public find = <R extends T[K]>(entryId: R) =>
+        this.data$.value.find(e => e[this.idProperty] === entryId)
 
     public get = (index: number) =>
         this.data$.value[index]
 
-    public patchRow(id: number | string, patch: PropertyMap<T>) {
-        const entry = this.data$.value.find(e => e.id === id);
-
+    public patchRow(id: T[K], patch: PropertyMap<T>) {
+        const entry = this.data$.value.find(e => e[this.idProperty] === id);
         if (!entry) {
             if (isDevMode()) {
-                console.warn(`Could not patch entity ${id}. Skipping patch...`);
+                console.warn(`Could not patch entity ${this.idProperty}. Skipping patch...`);
             }
+            return;
+        }
+
+        if (!this.useCache) {
+            const data = this.data$.value.slice(0);
+            const index = data.indexOf(entry);
+
+            assignWith(entry, patch, customPatch);
+            data.splice(index, 1, { ...entry });
+            this.data$.next(data);
+
             return;
         }
 
@@ -96,8 +122,13 @@ export class DataManager<T extends IGridDataEntry> {
 
         data = cloneDeep(data || []);
 
-        if (data.some(e => e.id == null)) {
-            throw new Error(`The 'id' property is a missin in: ${JSON.stringify(data, null, 4)}`);
+        if (!this.useCache) {
+            this._emit(data);
+            return;
+        }
+
+        if (data.some(e => e[this.idProperty] == null)) {
+            throw new Error(`The '${this.idProperty}' property is a missing in: ${JSON.stringify(data, null, 4)}`);
         }
 
         const cache = this.data$.value;
@@ -138,10 +169,10 @@ export class DataManager<T extends IGridDataEntry> {
         this.data$.complete();
     }
 
-    public hashTrack = (_: number | undefined | null, entry: T) => this._hashMap.get(entry.id);
+    public hashTrack = (_: number | undefined | null, entry: T) => this._hashMap.get(`${entry[this.idProperty]}`);
 
     private _hash = (entry: T) =>
-        this._hashMap.set(entry.id, hash.MD5(entry))
+        this._hashMap.set(`${entry[this.idProperty]}`, hash.MD5(entry))
 
     private _emit(data?: T[]) {
         this.data$.next([...(data || this.data$.value)]);

--- a/projects/angular/components/ui-grid/src/public_api.ts
+++ b/projects/angular/components/ui-grid/src/public_api.ts
@@ -1,6 +1,6 @@
 export { UiGridModule } from './ui-grid.module';
 export { UiGridIntl } from './ui-grid.intl';
-export { UiGridComponent } from './ui-grid.component';
+export { UiGridComponent, UI_GRID_OPTIONS } from './ui-grid.component';
 export {
     IDropdownOption,
     UiGridDropdownFilterDirective,

--- a/projects/angular/components/ui-grid/src/ui-grid.component.ts
+++ b/projects/angular/components/ui-grid/src/ui-grid.component.ts
@@ -1,4 +1,8 @@
-import type { QueryList } from '@angular/core';
+import {
+    Inject,
+    InjectionToken,
+    QueryList,
+} from '@angular/core';
 import {
     AfterContentInit,
     ChangeDetectionStrategy,
@@ -51,6 +55,7 @@ import { UiGridFooterDirective } from './footer/ui-grid-footer.directive';
 import { UiGridHeaderDirective } from './header/ui-grid-header.directive';
 import {
     DataManager,
+    DataManagerOptions,
     FilterManager,
     LiveAnnouncerManager,
     PerformanceMonitor,
@@ -67,6 +72,8 @@ import {
     ISortModel,
 } from './models';
 import { UiGridIntl } from './ui-grid.intl';
+
+export const UI_GRID_OPTIONS = new InjectionToken<DataManagerOptions<unknown>>('UiGrid DataManager options.');
 
 @Component({
     selector: 'ui-grid',
@@ -333,7 +340,7 @@ export class UiGridComponent<T extends IGridDataEntry> extends ResizableGrid<T> 
      * Data manager, used to optimize row rendering.
      *
      */
-    public dataManager = new DataManager<T>();
+    public dataManager = new DataManager<T>(this._dataManagerOptions);
 
     /**
      * Filter manager, used to manage filter state changes.
@@ -430,6 +437,9 @@ export class UiGridComponent<T extends IGridDataEntry> extends ResizableGrid<T> 
         protected _cd: ChangeDetectorRef,
         private _zone: NgZone,
         private _queuedAnnouncer: QueuedAnnouncer,
+        @Inject(UI_GRID_OPTIONS)
+        @Optional()
+        private _dataManagerOptions?: DataManagerOptions<T>,
     ) {
         super();
 

--- a/projects/angular/package.json
+++ b/projects/angular/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@uipath/angular",
-    "version": "11.0.0-rc.1",
+    "version": "11.0.0-rc.2",
     "license": "MIT",
     "author": {
         "name": "UiPath Inc",


### PR DESCRIPTION
Historically the Grid was optimized for IE11's slow execution
That meant we needed to manually keep the same references to the objects in order to avoid whole rows repaints.
That however meant we can't leverage the row element's reference for change detection – and we now have a config to change that.