### PR TITLE
fix: a11y grid 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+# v11.0.0-rc.5 (2021-03-30)
+* **password-indicator**  implement proper a11y support
+* **a11y** add mat-icon[tabindex] to auto-accessible-label directive
+* **testing**  allow multiple modifiers on key up & down
+* **drag-and-drop-file** add keyboard usability to drag & drop
+* **grid** add row headers for a11y
+* **grid** announce header actions on selection
+
 # v11.0.0-rc.4 (2021-03-12)
 * **BREAKING CHANGE** grid remove cdk experimental, add rowSize
 * **grid** update no content template

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "angular-components",
-  "version": "11.0.0-rc.4",
+  "version": "11.0.0-rc.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "angular-components",
-  "version": "11.0.0-rc.4",
+  "version": "11.0.0-rc5",
   "author": {
     "name": "UiPath Inc",
     "url": "https://uipath.com"

--- a/projects/angular/components/ui-grid/src/body/ui-grid-column.directive.spec.ts
+++ b/projects/angular/components/ui-grid/src/body/ui-grid-column.directive.spec.ts
@@ -49,7 +49,7 @@ class TestFixtureComponent {
     public method?: string;
     public sort?: 'asc' | 'desc' | '';
     public refetch?: boolean;
-    public primary?: boolean;
+    public primary = false;
     public minWidth?: number;
 }
 
@@ -92,6 +92,9 @@ describe('Component: UiGridColumn', () => {
             it('should have visible set to false', () => {
                 expect(column.visible).toBeFalse();
             });
+            it('should have primary set to false', () => {
+                expect(column.primary).toBeFalse();
+            });
 
             it('should have all properties undefined', () => {
                 expect(column.width).toBeNaN();
@@ -103,7 +106,6 @@ describe('Component: UiGridColumn', () => {
                 expect(column.property).toBeUndefined();
                 expect(column.method).toBeUndefined();
                 expect(column.sort).toBeUndefined();
-                expect(column.primary).toBeUndefined();
                 expect(column.minWidth).toBeUndefined();
             });
         });

--- a/projects/angular/components/ui-grid/src/body/ui-grid-column.directive.ts
+++ b/projects/angular/components/ui-grid/src/body/ui-grid-column.directive.ts
@@ -34,7 +34,7 @@ const ARIA_SORT_MAP: Record<SortDirection, string> = {
  * @ignore
  */
 const REACTIVE_INPUT_LIST: (keyof UiGridColumnDirective<{}>)[]
-    = ['sort', 'visible', 'title'];
+    = ['sort', 'visible', 'title', 'primary'];
 
 /**
  * The grid column definition directive.
@@ -144,7 +144,17 @@ export class UiGridColumnDirective<T> implements OnChanges, OnDestroy {
      *
      */
     @Input()
-    public primary = false;
+    public get primary() {
+        return this._primary;
+    }
+    public set primary(primary: boolean) {
+        if (primary === this._primary) { return; }
+        this._primary = !!primary;
+
+        this.change$.next({
+            primary: new SimpleChange(!primary, primary, false),
+        });
+    }
 
     /**
      * If the column can have visibility toggled.
@@ -219,6 +229,7 @@ export class UiGridColumnDirective<T> implements OnChanges, OnDestroy {
 
     private _width = NaN;
     private _visible = true;
+    private _primary = false;
 
     /**
      * @ignore

--- a/projects/angular/components/ui-grid/src/managers/selection-manager.spec.ts
+++ b/projects/angular/components/ui-grid/src/managers/selection-manager.spec.ts
@@ -31,6 +31,7 @@ describe('Component: UiGrid', () => {
 
             it('should NOT have a value', () => {
                 expect(manager.hasValue()).toEqual(false);
+                expect(manager['_hasValue$'].getValue()).toEqual(false);
             });
 
             it('should be empty', () => {
@@ -98,6 +99,7 @@ describe('Component: UiGrid', () => {
 
             it('should have a value', () => {
                 expect(manager.hasValue()).toEqual(true);
+                expect(manager['_hasValue$'].getValue()).toEqual(true);
             });
 
             it('should NOT be empty', () => {
@@ -155,6 +157,7 @@ describe('Component: UiGrid', () => {
 
             it('should have a value', () => {
                 expect(manager.hasValue()).toEqual(true);
+                expect(manager['_hasValue$'].getValue()).toEqual(true);
             });
 
             it('should NOT be empty', () => {

--- a/projects/angular/components/ui-grid/src/managers/selection-manager.ts
+++ b/projects/angular/components/ui-grid/src/managers/selection-manager.ts
@@ -1,6 +1,10 @@
 import cloneDeep from 'lodash-es/cloneDeep';
 import differenceBy from 'lodash-es/differenceBy';
-import { Subject } from 'rxjs';
+import {
+    BehaviorSubject,
+    Subject,
+} from 'rxjs';
+import { distinctUntilChanged } from 'rxjs/operators';
 
 import {
     SelectionChange,
@@ -33,6 +37,10 @@ export class SelectionManager<T extends IGridDataEntry> {
     }
 
     public changed$: Subject<SelectionChange<T>> = new Subject();
+
+    private _hasValue$ = new BehaviorSubject(false);
+
+    public hasValue$ = this._hasValue$.pipe(distinctUntilChanged());
 
     private _selection = new Map<number | string, T>();
 
@@ -93,6 +101,7 @@ export class SelectionManager<T extends IGridDataEntry> {
     private _updateState = (predicate: (value: T) => void, values: T[]) => {
         values.forEach(predicate);
         this._emitChangeEvent();
+        this._hasValue$.next(this.hasValue());
     }
 
     private _emitChangeEvent() {

--- a/projects/angular/components/ui-grid/src/ui-grid.component.html
+++ b/projects/angular/components/ui-grid/src/ui-grid.component.html
@@ -271,6 +271,7 @@
                 </mat-checkbox>
             </div>
             <div *ngIf="!!actions"
+                 role="gridcell"
                  class="ui-grid-mobile-feature-container ui-grid-mobile-action-container">
                 <ng-container *ngTemplateOutlet="actions.html; context: {
                     data: row,
@@ -294,24 +295,25 @@
                           tabindex="0">
             </mat-checkbox>
         </div>
-        <ng-container *ngFor="let column of visible$ | async">
-            <div [class.ui-grid-primary]="column.primary"
-                 [class.ui-grid-secondary]="!column.primary"
-                 [class.ui-grid-state-resizing]="column === resizeManager.current?.column"
-                 [attr.data-property]="column.property"
-                 [attr.data-identifier]="column.identifier"
-                 [style.width.%]="column.width"
-                 class="ui-grid-cell"
-                 role="gridcell">
+
+        <ng-container *ngFor="let column of renderedColumns$ | async">
+            <div [class.ui-grid-primary]="column.directive.primary"
+                 [class.ui-grid-secondary]="!column.directive.primary"
+                 [class.ui-grid-state-resizing]="column.directive === resizeManager.current?.column"
+                 [attr.data-property]="column.directive.property"
+                 [attr.data-identifier]="column.directive.identifier"
+                 [style.width.%]="column.directive.width"
+                 [attr.role]="column.role"
+                 class="ui-grid-cell">
                 <div *ngIf="isProjected"
-                     [matTooltip]="column.title"
+                     [matTooltip]="column.directive.title"
                      [matTooltipDisabled]="resizeManager.isResizing"
-                     class="ui-grid-cell-mobile-title">{{column.title}}</div>
+                     class="ui-grid-cell-mobile-title">{{column.directive.title}}</div>
                 <div class="ui-grid-cell-content">
-                    <ng-container *ngTemplateOutlet="column.html || textCellTemplate; context: {
+                    <ng-container *ngTemplateOutlet="column.directive.html || textCellTemplate; context: {
                             data: row,
                             index: index,
-                            property: column.property
+                            property: column.directive.property
                         }">
                     </ng-container>
                 </div>
@@ -329,6 +331,7 @@
 
         <div *ngIf="!isProjected &&
                     !!actions"
+             role="gridcell"
              class="ui-grid-cell ui-grid-action-cell ui-grid-feature-cell">
             <div class="ui-grid-action-cell-container">
                 <ng-container *ngTemplateOutlet="actions.html; context: {

--- a/projects/angular/components/ui-grid/src/ui-grid.component.html
+++ b/projects/angular/components/ui-grid/src/ui-grid.component.html
@@ -14,7 +14,7 @@
         <ng-container *ngTemplateOutlet="toggleColumnsTmpl"></ng-container>
     </ng-container>
 
-    <ng-container *ngIf="!selectionManager.hasValue() ||
+    <ng-container *ngIf="!(hasSelection$ | async) ||
                    !header?.actionButtons?.length">
         <ui-grid-search *ngIf="header?.search"
                         [debounce]="header!.searchDebounce"
@@ -37,7 +37,7 @@
         <ng-container *ngTemplateOutlet="toggleColumnsTmpl"></ng-container>
     </ng-container>
 
-    <div *ngIf="!selectionManager.hasValue()"
+    <div *ngIf="!(hasSelection$ | async)"
          class="ui-grid-action-buttons ui-grid-action-buttons-inline">
         <ng-container *ngFor="let button of header?.inlineButtons">
             <ng-container *ngIf="button.visible">
@@ -47,7 +47,8 @@
         </ng-container>
     </div>
 
-    <div *ngIf="selectionManager.hasValue()"
+    <div #gridActionButtons
+         *ngIf="hasSelection$ | async"
          class="ui-grid-action-buttons ui-grid-action-buttons-selection">
         <ng-container *ngFor="let button of header?.actionButtons">
             <ng-container *ngIf="button.visible">
@@ -78,6 +79,7 @@
 </ng-container>
 
 <div [class.use-alternate-design]="useAlternateDesign"
+     (keydown.shift.alt.arrowup)="focusRowHeader()"
      class="ui-grid-container">
 
     <div class="ui-grid-table-container">
@@ -545,7 +547,7 @@
 </ng-template>
 
 <ng-template #toggleColumnsTmpl>
-    <ui-grid-toggle-columns *ngIf="toggleColumns && !selectionManager.hasValue()"
+    <ui-grid-toggle-columns *ngIf="toggleColumns && !(hasSelection$ | async)"
                             [options]="visibilityManager.options$ | async"
                             [dirty]="visibilityManager.isDirty$ | async"
                             [toggleTooltip]="intl.toggleTooltip"

--- a/projects/angular/components/ui-grid/src/ui-grid.component.spec.ts
+++ b/projects/angular/components/ui-grid/src/ui-grid.component.spec.ts
@@ -856,6 +856,59 @@ describe('Component: UiGrid', () => {
                 expect(headerSelectionAction.nativeElement.innerText).toEqual('Selection Action');
             });
 
+            it('should be able to move focus to selection action button if at least one row is selected', () => {
+                const rowCheckboxInputList = fixture.debugElement
+                    .queryAll(By.css('.ui-grid-row .ui-grid-cell.ui-grid-checkbox-cell input'));
+
+                const checkboxInput = faker.helpers.randomize(rowCheckboxInputList);
+
+                checkboxInput.nativeElement.dispatchEvent(EventGenerator.click);
+
+                fixture.detectChanges();
+
+                const headerSelectionAction = fixture.debugElement.query(By.css('.selection-action-button'));
+                expect(headerSelectionAction).toBeDefined();
+
+                const gridContainer = fixture.debugElement.query(By.css('.ui-grid-container'));
+                gridContainer.nativeElement.dispatchEvent(
+                    EventGenerator.keyDown(Key.ArrowUp, Key.Shift, Key.Alt),
+                );
+                fixture.detectChanges();
+                expect(document.activeElement).toEqual(headerSelectionAction.nativeElement);
+            });
+
+            it('should live announce the header actions when there is a selection in the grid', () => {
+                const intl = new UiGridIntl();
+                spyOn<any>(component.grid['_queuedAnnouncer'], 'enqueue');
+
+                const rowCheckboxInputList = fixture.debugElement
+                    .queryAll(By.css('.ui-grid-row .ui-grid-cell.ui-grid-checkbox-cell input'));
+
+                const checkboxInput = faker.helpers.randomize(rowCheckboxInputList);
+
+                checkboxInput.nativeElement.dispatchEvent(EventGenerator.click);
+
+                fixture.detectChanges();
+
+                expect(component.grid['_queuedAnnouncer']['enqueue']).toHaveBeenCalledTimes(1);
+                expect(component.grid['_queuedAnnouncer']['enqueue']).toHaveBeenCalledWith(intl.gridHeaderActionsNotice);
+            });
+
+            it('should live announce the header actions only once if there are multiple items selected and deselected', () => {
+                spyOn<any>(component.grid['_queuedAnnouncer'], 'enqueue');
+
+                const rowCheckboxInputList = fixture.debugElement
+                    .queryAll(By.css('.ui-grid-row .ui-grid-cell.ui-grid-checkbox-cell input'));
+
+                rowCheckboxInputList.forEach(row => row.nativeElement.dispatchEvent(EventGenerator.click));
+
+                fixture.detectChanges();
+
+                rowCheckboxInputList.forEach(row => row.nativeElement.dispatchEvent(EventGenerator.click));
+
+                expect(component.grid['_queuedAnnouncer']['enqueue']).toHaveBeenCalledTimes(1);
+            });
+
             it('should NOT display the inline header button if at least one row is selected', () => {
                 const rowCheckboxInputList = fixture.debugElement
                     .queryAll(By.css('.ui-grid-row .ui-grid-cell.ui-grid-checkbox-cell input'));

--- a/projects/angular/components/ui-grid/src/ui-grid.component.spec.ts
+++ b/projects/angular/components/ui-grid/src/ui-grid.component.spec.ts
@@ -255,6 +255,27 @@ describe('Component: UiGrid', () => {
                         expect(nestedDateCell.nativeElement.innerText).toContain(dataEntry.myObj.myObjDate.toString());
                     });
                 });
+
+                it('should mark first column cells as row headers when no primary column is set', () => {
+                    fixture.detectChanges();
+                    const firstRow = fixture.debugElement.query(By.css('.ui-grid-row'));
+                    const [firstCell, secondCell, thirdCell] = firstRow.queryAll(By.css('.ui-grid-cell'));
+                    expect(firstCell.nativeElement.getAttribute('role')).toBe('rowheader');
+                    expect(secondCell.nativeElement.getAttribute('role')).toBe('gridcell');
+                    expect(thirdCell.nativeElement.getAttribute('role')).toBe('gridcell');
+                });
+
+                it('should mark only one column cell as row header when there are multiple primary columns', fakeAsync(() => {
+                    grid.columns.forEach((col, idx) => col.primary = idx > 0);
+                    fixture.detectChanges();
+                    tick(GRID_COLUMN_CHANGE_DELAY);
+                    fixture.detectChanges();
+                    const firstRow = fixture.debugElement.query(By.css('.ui-grid-row'));
+                    const [firstCell, secondCell, thirdCell] = firstRow.queryAll(By.css('.ui-grid-cell'));
+                    expect(firstCell.nativeElement.getAttribute('role')).toBe('gridcell');
+                    expect(secondCell.nativeElement.getAttribute('role')).toBe('rowheader');
+                    expect(thirdCell.nativeElement.getAttribute('role')).toBe('gridcell');
+                }));
             });
         });
 

--- a/projects/angular/components/ui-grid/src/ui-grid.component.ts
+++ b/projects/angular/components/ui-grid/src/ui-grid.component.ts
@@ -496,6 +496,19 @@ export class UiGridComponent<T extends IGridDataEntry> extends ResizableGrid<T> 
         tap(compensationWidth => this.scrollCompensationWidth = compensationWidth),
     );
 
+
+    public renderedColumns$ = this.visible$.pipe(
+        map(columns => {
+            const firstIndex = columns.findIndex(c => c.primary);
+            const rowHeaderIndex = firstIndex > -1 ? firstIndex : 0;
+
+            return columns.map((directive, index) => ({
+                directive,
+                role: index === rowHeaderIndex ? 'rowheader' : 'gridcell',
+            }));
+        }),
+    );
+
     /**
      * Determines if the multi-page selection row should be displayed.
      *

--- a/projects/angular/components/ui-grid/src/ui-grid.component.ts
+++ b/projects/angular/components/ui-grid/src/ui-grid.component.ts
@@ -14,6 +14,7 @@ import {
     filter,
     map,
     observeOn,
+    share,
     shareReplay,
     startWith,
     switchMap,
@@ -48,6 +49,7 @@ import {
     Output,
     QueryList,
     SimpleChanges,
+    ViewChild,
     ViewEncapsulation,
 } from '@angular/core';
 import { MatCheckboxChange } from '@angular/material/checkbox';
@@ -85,6 +87,7 @@ import { UiGridIntl } from './ui-grid.intl';
 
 export const UI_GRID_OPTIONS = new InjectionToken<GridOptions<unknown>>('UiGrid DataManager options.');
 const DEFAULT_VIRTUAL_SCROLL_ITEM_SIZE = 48;
+const FOCUSABLE_ELEMENTS_QUERY = 'a, button:not([hidden]), input:not([hidden]), textarea, select, details, [tabindex]:not([tabindex="-1"])';
 
 @Component({
     selector: 'ui-grid',
@@ -404,6 +407,13 @@ export class UiGridComponent<T extends IGridDataEntry> extends ResizableGrid<T> 
     })
     public loadingState?: UiGridLoadingDirective;
     /**
+     * Reference to the grid action buttons container
+     *
+     * @ignore
+     */
+    @ViewChild('gridActionButtons')
+    public gridActionButtons!: ElementRef;
+    /**
      * Toggle filters row display state
      *
      */
@@ -496,6 +506,14 @@ export class UiGridComponent<T extends IGridDataEntry> extends ResizableGrid<T> 
         tap(compensationWidth => this.scrollCompensationWidth = compensationWidth),
     );
 
+    public hasSelection$ = this.selectionManager.hasValue$.pipe(
+        tap(hasSelection => {
+            if (hasSelection && !!this.header?.actionButtons?.length) {
+                this._announceGridHeaderActions();
+            }
+        }),
+        share(),
+    );
 
     public renderedColumns$ = this.visible$.pipe(
         map(columns => {
@@ -793,5 +811,13 @@ export class UiGridComponent<T extends IGridDataEntry> extends ResizableGrid<T> 
             return `${this.isEveryVisibleRowChecked ? 'select' : 'deselect'} all`;
         }
         return `${this.selectionManager.isSelected(row) ? 'deselect' : 'select'} row ${this.dataManager.indexOf(row)}`;
+    }
+
+    public focusRowHeader() {
+        this.gridActionButtons?.nativeElement.querySelector(FOCUSABLE_ELEMENTS_QUERY)?.focus();
+    }
+
+    private _announceGridHeaderActions() {
+        this._queuedAnnouncer.enqueue(this.intl.gridHeaderActionsNotice);
     }
 }

--- a/projects/angular/components/ui-grid/src/ui-grid.intl.ts
+++ b/projects/angular/components/ui-grid/src/ui-grid.intl.ts
@@ -103,6 +103,11 @@ export class UiGridIntl implements OnDestroy {
      */
     public descending = 'descending';
     /**
+     * Live announced text when new action buttons are revealed on selection
+     *
+     */
+    public gridHeaderActionsNotice = 'Grid header actions updated. Press Shift + Alt + Arrow Up to move there.';
+    /**
      * No data row message alternative function.
      *
      */

--- a/projects/angular/directives/ui-drag-and-drop-file/src/ui-drag-and-drop-file.directive.spec.ts
+++ b/projects/angular/directives/ui-drag-and-drop-file/src/ui-drag-and-drop-file.directive.spec.ts
@@ -10,6 +10,7 @@ import {
     EventGenerator,
     FakeFileList,
     IDropEvent,
+    Key,
 } from '@uipath/angular/testing';
 
 import { UiDragAndDropFileDirective } from './ui-drag-and-drop-file.directive';
@@ -109,15 +110,20 @@ describe('Directive: UiDragAndDropFileDirective', () => {
             expect(fileInput.getAttribute('accept')).toBe(fileTypes);
         });
 
+        [
+            { name: 'click', obj: EventGenerator.click },
+            { name: 'Keydown.Enter', obj: EventGenerator.keyDown(Key.Enter) },
+            { name: 'Keydown.Space', obj: EventGenerator.keyDown(Key.Space) },
+        ].forEach(event => {
+            it(`should trigger browse when ${event.name} is triggered on the parent container`, () => {
+                const spy = spyOn(fileInput, 'click');
 
-        it('should trigger browse when parent container is clicked', () => {
-            const spy = spyOn(fileInput, 'click');
+                const container = fixture.debugElement.query(By.css('div'));
 
-            const container = fixture.debugElement.query(By.css('div'));
+                container.nativeElement.dispatchEvent(event.obj);
 
-            container.nativeElement.dispatchEvent(EventGenerator.click);
-
-            expect(spy).toHaveBeenCalled();
+                expect(spy).toHaveBeenCalledTimes(1);
+            });
         });
 
         it('should be hidden', () => {

--- a/projects/angular/directives/ui-drag-and-drop-file/src/ui-drag-and-drop-file.directive.ts
+++ b/projects/angular/directives/ui-drag-and-drop-file/src/ui-drag-and-drop-file.directive.ts
@@ -118,12 +118,14 @@ export class UiDragAndDropFileDirective implements OnChanges, AfterViewInit, OnD
 
         this._renderer.setStyle(this.fileBrowseRef, 'cursor', 'pointer');
 
-        const browse = this._renderer
-            .listen(this.fileBrowseRef, 'click', () => {
-                if (this.disabled) { return; }
-                this._fileInput.click();
-            });
-        this._disposalCallbacks.push(browse);
+        ['click', 'keydown.enter', 'keydown.space'].forEach(eventName => {
+            const browse = this._renderer
+                .listen(this.fileBrowseRef, eventName, () => {
+                    if (this.disabled) { return; }
+                    this._fileInput.click();
+                });
+            this._disposalCallbacks.push(browse);
+        });
 
         const change = this._renderer.listen(this._fileInput, 'change', (ev) => {
             this._preventAll(ev);

--- a/projects/angular/package.json
+++ b/projects/angular/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@uipath/angular",
-    "version": "11.0.0-rc.4",
+    "version": "11.0.0-rc.5",
     "license": "MIT",
     "author": {
         "name": "UiPath Inc",

--- a/projects/angular/testing/src/utilities/event-generator.ts
+++ b/projects/angular/testing/src/utilities/event-generator.ts
@@ -124,22 +124,22 @@ export class EventGenerator {
      * KeyDown event generator helper.
      *
      * @param key The pressed key.
-     * @param [modifier] The active modifier, if any.
+     * @param [modifiers] The active modifiers, if any.
      * @returns A `keydown` event with the provided key and modifier metadata.
      */
-    static keyDown(key: KeyOrKeyName, modifier?: IKeyModifier): KeyboardEvent {
-        return EventGenerator._key('keydown', key, modifier);
+    static keyDown(key: KeyOrKeyName, ...modifiers: IKeyModifier[]): KeyboardEvent {
+        return EventGenerator._key('keydown', key, modifiers);
     }
 
     /**
      * KeyUp event generator helper.
      *
      * @param key The pressed key.
-     * @param [modifier] The active modifier, if any.
+     * @param [modifiers] The active modifier, if any.
      * @returns A `keyup` event with the provided key and modifier metadata.
      */
-    static keyUp(key: KeyOrKeyName, modifier?: IKeyModifier): KeyboardEvent {
-        return EventGenerator._key('keyup', key, modifier);
+    static keyUp(key: KeyOrKeyName, ...modifiers: IKeyModifier[]): KeyboardEvent {
+        return EventGenerator._key('keyup', key, modifiers);
     }
 
     /**
@@ -241,15 +241,15 @@ export class EventGenerator {
         return event;
     }
 
-    private static _key(type: string, key: IKey | keyof Key, modifier = {} as IKeyModifier) {
+    private static _key(type: string, key: IKey | keyof Key, modifiers = [] as IKeyModifier[]) {
         const safeKey = EventGenerator._getKey(key) as IKey;
         const options: KeyboardEventInit & { keyCode: number } = {
             code: `${safeKey.code}`,
             key: safeKey.name,
             keyCode: safeKey.keyCode,
-            shiftKey: modifier === Key.Shift,
-            altKey: modifier === Key.Alt,
-            ctrlKey: modifier === Key.Control,
+            shiftKey: modifiers.includes(Key.Shift),
+            altKey: modifiers.includes(Key.Alt),
+            ctrlKey: modifiers.includes(Key.Control),
         };
 
         return new KeyboardEvent(type, options);


### PR DESCRIPTION
- [x] add cell headers association - assure row headers
- [x] reveal changes in header when a selection is made and action buttons are available
  - the user is announced of the change and he can also press `Shift + ALT + Arrow Up` to navigate straight to the newly revealed actions
- [x] add enter and space to event listeners for drag and drop directive to ensure the file browsing can be triggered by keyboard