### PR TITLE
fix(a11y): add mat-icon[tabindex] to auto-accessible-label directive

### DIFF
--- a/projects/angular/a11y/src/ui-auto-accessible-label/ui-auto-accessible-label.directive.ts
+++ b/projects/angular/a11y/src/ui-auto-accessible-label/ui-auto-accessible-label.directive.ts
@@ -22,7 +22,8 @@ You can disable this directive using the boolean ${DISABLE_AUTO_ACCESSIBLE_LABEL
     // tslint:disable-next-line: directive-selector
     selector: ` [mat-fab]:not([${DISABLE_AUTO_ACCESSIBLE_LABEL_ATTRIBUTE}]),
                 [mat-mini-fab]:not([${DISABLE_AUTO_ACCESSIBLE_LABEL_ATTRIBUTE}]),
-                [mat-icon-button]:not([${DISABLE_AUTO_ACCESSIBLE_LABEL_ATTRIBUTE}])`,
+                [mat-icon-button]:not([${DISABLE_AUTO_ACCESSIBLE_LABEL_ATTRIBUTE}]),
+                mat-icon[tabindex]:not([${DISABLE_AUTO_ACCESSIBLE_LABEL_ATTRIBUTE}])`,
 })
 export class UiAutoAccessibleLabelDirective {
     @HostBinding('attr.aria-label')


### PR DESCRIPTION
Add support for auto-adding aria-label based on matTooltip to mat-icons that have tabindex.