### PR TITLE
fix(grid): add type="button" to filter button

### DIFF
--- a/projects/angular/components/ui-grid/src/ui-grid.component.html
+++ b/projects/angular/components/ui-grid/src/ui-grid.component.html
@@ -485,6 +485,7 @@
                 [disabled]="disabled"
                 (click)="showFilters = !showFilters"
                 mat-button
+                type="button"
                 class="ui-grid-collapsible-filters-toggle">
             <mat-icon>filter_list</mat-icon>
             <span>{{ intl.filters(filterManager.activeCount$ | async)}}</span>


### PR DESCRIPTION
by default a button within a form has a type="submit" which triggers form submission