### PR TITLE
fix(suggest): add aria-label to combo box

### DIFF
--- a/projects/angular/components/ui-suggest/src/ui-suggest.component.html
+++ b/projects/angular/components/ui-suggest/src/ui-suggest.component.html
@@ -16,7 +16,7 @@
          [uiAutofocus]="!isOpen && focus"
          [refocus]="!isOpen && focus"
          [matRippleDisabled]="isFormControl"
-         [attr.aria-label]="placeholder"
+         [attr.aria-label]="ariaLabel + placeholder"
          [attr.aria-describedby]="describedBy"
          [attr.aria-required]="required"
          [attr.aria-disabled]="disabled || readonly"

--- a/projects/angular/components/ui-suggest/src/ui-suggest.component.ts
+++ b/projects/angular/components/ui-suggest/src/ui-suggest.component.ts
@@ -243,6 +243,13 @@ export class UiSuggestComponent extends UiSuggestMatFormFieldDirective
     }
 
     /**
+     * Aria label for the combo box
+     *
+     */
+    @Input()
+    ariaLabel = '';
+
+    /**
      * Reference for custom item template
      *
      */


### PR DESCRIPTION
The `aria-label` attribute of the combo box consists of an input called `ariaLabel` concatenated with the placeholder value.