### PR TITLE
fix(suggest): prevent fetch after select

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# v13.0.0-rc.12 (2022-01-28)
+* **suggest** prevent fetch after select
+
 # v13.0.0-rc.11 (2022-01-27)
 * **suggest** add multiple custom value support
 * **chore** change playground port

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "angular-components",
-  "version": "13.0.0-rc.11",
+  "version": "13.0.0-rc.12",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "angular-components",
-  "version": "13.0.0-rc.11",
+  "version": "13.0.0-rc.12",
   "author": {
     "name": "UiPath Inc",
     "url": "https://uipath.com"

--- a/projects/angular/components/ui-suggest/src/ui-suggest.component.spec.ts
+++ b/projects/angular/components/ui-suggest/src/ui-suggest.component.spec.ts
@@ -367,11 +367,14 @@ const sharedSpecifications = (
             fixture.detectChanges();
         });
 
-        it('should emit update event EVERY TIME the source queried', (done) => {
+        it('should emit update event EVERY TIME the source queried', fakeAsync(() => {
             const items = generateSuggetionItemList(25);
 
             component.searchable = true;
             component.items = items;
+
+            fixture.detectChanges();
+            tick(1);
 
             uiSuggest.sourceUpdated
                 .pipe(
@@ -383,6 +386,8 @@ const sharedSpecifications = (
                     setTimeout(() => searchFor(faker.helpers.randomize(items).text, fixture), 100);
                 });
 
+            tick(100);
+
             uiSuggest.sourceUpdated
                 .pipe(
                     skip(1),
@@ -392,18 +397,18 @@ const sharedSpecifications = (
                     setTimeout(() => searchFor('', fixture), 100);
                 });
 
+            tick(100);
+
             uiSuggest.sourceUpdated
                 .pipe(
                     skip(2),
                     take(1),
-                    finalize(done),
                 ).subscribe(result => {
                     expect(result.length).toEqual(uiSuggest.items.length);
-                    done();
                 });
 
-            fixture.detectChanges();
-        });
+            tick(1000);
+        }));
 
         it('should emit selected on select item', async (done) => {
             const items = generateSuggetionItemList();
@@ -1805,10 +1810,9 @@ const sharedSpecifications = (
 
                 expect(sourceSpy).toHaveBeenCalled();
             }));
-            // FIXME: flaky test
-            // eslint-disable-next-line jasmine/no-disabled-tests
-            xit('should call fetch 2 times if fetchStrategy is `onOpen`, direction is `up` and suggest gets opened twice', waitForAsync(
-                async () => {
+
+            it('should call fetch 2 times if fetchStrategy is `onOpen`, direction is `up` and suggest gets opened once', fakeAsync(
+                () => {
                     component.fetchStrategy = 'onOpen';
                     component.direction = 'up';
                     overrideItems = new Array(6).fill(0).map((_, i) => ({
@@ -1821,7 +1825,7 @@ const sharedSpecifications = (
                     sourceSpy.and.callThrough();
 
                     fixture.detectChanges();
-                    await fixture.whenStable();
+                    tick(1000);
 
                     expect(sourceSpy).toHaveBeenCalledTimes(0);
 
@@ -1829,11 +1833,9 @@ const sharedSpecifications = (
                     display.nativeElement.dispatchEvent(EventGenerator.click);
 
                     fixture.detectChanges();
-                    await fixture.whenStable();
+                    tick(1000);
 
-                    fixture.detectChanges();
-
-                    expect(sourceSpy).toHaveBeenCalledTimes(2);
+                    expect(sourceSpy).toHaveBeenCalledTimes(1);
 
                     uiSuggest.close();
                     fixture.detectChanges();
@@ -1841,11 +1843,9 @@ const sharedSpecifications = (
                     display.nativeElement.dispatchEvent(EventGenerator.click);
 
                     fixture.detectChanges();
-                    await fixture.whenStable();
+                    tick(1000);
 
-                    fixture.detectChanges();
-
-                    expect(sourceSpy).toHaveBeenCalledTimes(4);
+                    expect(sourceSpy).toHaveBeenCalledTimes(2);
                 }));
 
             it(`should fetch call after the 'minChars' is met`, waitForAsync(async () => {

--- a/projects/angular/components/ui-suggest/src/ui-suggest.component.ts
+++ b/projects/angular/components/ui-suggest/src/ui-suggest.component.ts
@@ -16,6 +16,7 @@ import {
     filter,
     finalize,
     map,
+    pairwise,
     retry,
     startWith,
     switchMap,
@@ -651,6 +652,10 @@ export class UiSuggestComponent extends UiSuggestMatFormFieldDirective
             ),
             this._inputChange$,
         ).pipe(
+            startWith(''),
+            pairwise(),
+            filter(([prev, current]) => !(prev !== '' && current === '')),
+            map(([_, current]) => current),
             takeUntil(this._destroyed$),
         ).subscribe(this.fetch);
 

--- a/projects/angular/package.json
+++ b/projects/angular/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@uipath/angular",
-    "version": "13.0.0-rc.11",
+    "version": "13.0.0-rc.12",
     "license": "MIT",
     "author": {
         "name": "UiPath Inc",


### PR DESCRIPTION
When selecting an item after search, the items value was updated,
thus causing an extra empty fetch