### PR TITLE
feat(suggest): expose input to allow fetching while closed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# v13.0.0-rc.13 (2022-01-31)
+* **suggest** expose input to allow fetching while closed consumers may use this to reset/refetch items even if closed in order to trigger validations
+
 # v13.0.0-rc.11 (2022-01-27)
 * **suggest** add multiple custom value support
 * **chore** change playground port

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "angular-components",
-  "version": "13.0.0-rc.12",
+  "version": "13.0.0-rc.13",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "angular-components",
-  "version": "13.0.0-rc.12",
+  "version": "13.0.0-rc.13",
   "author": {
     "name": "UiPath Inc",
     "url": "https://uipath.com"

--- a/projects/angular/components/ui-suggest/src/ui-suggest.component.ts
+++ b/projects/angular/components/ui-suggest/src/ui-suggest.component.ts
@@ -173,9 +173,15 @@ export class UiSuggestComponent extends UiSuggestMatFormFieldDirective
     }
 
     /**
+     * By default the onOpen fetchStrategy prevents additional requests if closed.
+     * This allows you to bypass that check and update even if closed.
+     */
+    @Input()
+    ignoreOpenOnFetch = false;
+
+    /**
      * If true, the item list will render open and will not close on selection
      *
-     * @ignore
      */
     @Input()
     alwaysExpanded = false;
@@ -977,6 +983,7 @@ export class UiSuggestComponent extends UiSuggestMatFormFieldDirective
     fetch = (searchValue = '') => {
         if (!this.searchSourceFactory ||
             this._fetchStrategy$.value === 'onOpen' &&
+            !this.ignoreOpenOnFetch &&
             !this.isOpen
         ) {
             return;

--- a/projects/angular/package.json
+++ b/projects/angular/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@uipath/angular",
-    "version": "13.0.0-rc.12",
+    "version": "13.0.0-rc.13",
     "license": "MIT",
     "author": {
         "name": "UiPath Inc",


### PR DESCRIPTION
consumers may use this to reset/refetch items even if closed in order to trigger validations