### PR TITLE
Fix/suggest header items

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# v13.4.1 (2022-06-22)
+* **suggest** hide no results when header items are available
+
 # v13.4.0 (2022-06-09)
 * **suggest** implement custom header slot
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "angular-components",
-  "version": "13.4.0",
+  "version": "13.4.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "angular-components",
-  "version": "13.4.0",
+  "version": "13.4.1",
   "author": {
     "name": "UiPath Inc",
     "url": "https://uipath.com"

--- a/projects/angular/components/ui-suggest/src/ui-suggest.component.html
+++ b/projects/angular/components/ui-suggest/src/ui-suggest.component.html
@@ -244,7 +244,7 @@
                 </ng-container>
             </ng-container>
 
-            <mat-divider *ngIf="headerItems!.length"></mat-divider>
+            <mat-divider *ngIf="headerItems!.length && !hasNoResults"></mat-divider>
 
             <ng-container *cdkVirtualFor="
                             let item of renderItems;
@@ -280,6 +280,7 @@
             ) as label">
                 <mat-list-item *ngIf="hasNoResults &&
                                   !isCustomValueVisible &&
+                                  !headerItems!.length &&
                                   (loading$ | async) === false"
                                [matTooltip]="label"
                                [attr.role]="'option'"

--- a/projects/angular/components/ui-suggest/src/ui-suggest.component.spec.ts
+++ b/projects/angular/components/ui-suggest/src/ui-suggest.component.spec.ts
@@ -1391,6 +1391,28 @@ const sharedSpecifications = (
                 expect(entry.nativeElement.innerText).toBe(regularItems[idx].text);
             });
         }));
+
+        it('should render headerItems when searchSourceFactory is empty', fakeAsync(() => {
+            const headerItems = generateSuggetionItemList(1, 'Item');
+            const regularItems = [] as ISuggestValue[];
+
+            component.alwaysExpanded = true;
+            component.items = regularItems;
+            component.headerItems = headerItems;
+            component.searchable = true;
+
+            fixture.detectChanges();
+            tick(1000);
+
+            const itemListEntries = fixture.debugElement.queryAll(By.css('.mat-list-item'));
+
+            expect(itemListEntries).not.toBeNull();
+            expect(itemListEntries.length).toEqual(1);
+
+            const [item] = itemListEntries;
+
+            expect(item.nativeElement.innerText).toBe(headerItems[0].text);
+        }));
     });
 
     describe('Selection: single value', () => {

--- a/projects/angular/package.json
+++ b/projects/angular/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@uipath/angular",
-    "version": "13.4.0",
+    "version": "13.4.1",
     "license": "MIT",
     "author": {
         "name": "UiPath Inc",


### PR DESCRIPTION
If 
- no results are provided upfront by `searchSourceFactory` 
- and `headerItems` are provided

hide the no-results template.