### PR TITLE
Feat: grid custom filter value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# v13.5.0 (2022-07-21)
+* **deps** add dom iterable in tsconfig
+* **grid** add tests for custom filter
+* **playground** add custom filter input
+* **grid** add input for custom filter value
+* **playground** convert filter value to string
+
 # v13.4.1 (2022-06-22)
 * **suggest** hide no results when header items are available
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "angular-components",
-  "version": "13.4.1",
+  "version": "13.5.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "angular-components",
-  "version": "13.4.1",
+  "version": "13.5.0",
   "author": {
     "name": "UiPath Inc",
     "url": "https://uipath.com"

--- a/projects/angular/components/ui-grid/src/managers/filter-manager.ts
+++ b/projects/angular/components/ui-grid/src/managers/filter-manager.ts
@@ -28,6 +28,9 @@ import { IFilterModel } from '../models';
  * @internal
  */
 export class FilterManager<T> {
+    hasCustomFilter$ = new BehaviorSubject(false);
+    customFilters?: IFilterModel<T>[];
+
     filter$ = new BehaviorSubject<IFilterModel<T>[]>([]);
 
     dirty$ = this.filter$.pipe(
@@ -105,6 +108,17 @@ export class FilterManager<T> {
         }
     }
 
+    updateCustomFilters(customValue: IFilterModel<T>[]) {
+        this.customFilters = customValue;
+        this.hasCustomFilter$.next(true);
+        this.filter$.next(customValue);
+    }
+
+    clearCustomFilters() {
+        this.hasCustomFilter$.next(false);
+        this._emitFilterOptions();
+    }
+
     private _updateFilterValue = (
         column: UiGridColumnDirective<T> | undefined,
         value: ISuggestValue | IDropdownOption | undefined,
@@ -142,7 +156,11 @@ export class FilterManager<T> {
             : [];
         if (isEqual(this.filter$.getValue(), updatedFilters)) { return; }
 
-        this.filter$.next(updatedFilters);
+        this.filter$.next(
+            this.hasCustomFilter$.value
+            ? this.customFilters!
+            : updatedFilters,
+        );
     };
 
     private _hasFilterValue = (dropdown?: UiGridSearchFilterDirective<T> | UiGridDropdownFilterDirective<T>) =>

--- a/projects/angular/components/ui-grid/src/ui-grid.component.html
+++ b/projects/angular/components/ui-grid/src/ui-grid.component.html
@@ -13,52 +13,64 @@
      class="ui-grid-filter-container">
     <div class="ui-grid-filter-container-lhs-group">
         <div class="ui-grid-filter-container-lhs-group-actions">
-            <ng-container *ngIf="useLegacyDesign">
+            <ng-container *ngIf="filterManager.hasCustomFilter$ | async; else noCustomFilter">
                 <ng-container *ngTemplateOutlet="toggleColumnsTmpl"></ng-container>
+                <button (click)="clearCustomFilter()"
+                        mat-flat-button type="button"
+                        data-cy="clear-custom-filter">
+                    {{ intl.clearCustomFilter }}
+                </button>
             </ng-container>
+            <ng-template #noCustomFilter>
+                <ng-container>
+                    <ng-container *ngIf="useLegacyDesign">
+                        <ng-container *ngTemplateOutlet="toggleColumnsTmpl"></ng-container>
+                    </ng-container>
 
-            <ng-container *ngIf="!(hasSelection$ | async) ||
-                       !header?.actionButtons?.length">
-                <ui-grid-search *ngIf="header?.search"
-                                [debounce]="header!.searchDebounce"
-                                [maxLength]="header!.searchMaxLength"
-                                [placeholder]="intl.searchPlaceholder"
-                                [searchTooltip]="intl.searchTooltip"
-                                [clearTooltip]="intl.clearTooltip"
-                                [tooltipDisabled]="resizeManager.isResizing"
-                                [value]="header!.searchValue!"
-                                (searchChange)="filterManager.searchChange($event, header!, footer)"
-                                class="ui-grid-search ui-grid-filter-option">
-                </ui-grid-search>
+                    <ng-container *ngIf="!(hasSelection$ | async) ||
+                            !header?.actionButtons?.length">
+                        <ui-grid-search *ngIf="header?.search"
+                                        [debounce]="header!.searchDebounce"
+                                        [maxLength]="header!.searchMaxLength"
+                                        [placeholder]="intl.searchPlaceholder"
+                                        [searchTooltip]="intl.searchTooltip"
+                                        [clearTooltip]="intl.clearTooltip"
+                                        [tooltipDisabled]="resizeManager.isResizing"
+                                        [value]="header!.searchValue!"
+                                        (searchChange)="filterManager.searchChange($event, header!, footer)"
+                                        class="ui-grid-search ui-grid-filter-option">
+                        </ui-grid-search>
 
-                <ng-container *ngIf="!useLegacyDesign">
-                    <ng-container *ngTemplateOutlet="toggleColumnsTmpl"></ng-container>
-                </ng-container>
+                        <ng-container *ngIf="!useLegacyDesign">
+                            <ng-container *ngTemplateOutlet="toggleColumnsTmpl"></ng-container>
+                        </ng-container>
 
-                <ng-container *ngTemplateOutlet="filtersTmpl">
-                </ng-container>
-            </ng-container>
-
-            <div *ngIf="!(hasSelection$ | async)"
-                 class="ui-grid-action-buttons ui-grid-action-buttons-inline">
-                <ng-container *ngFor="let button of header?.inlineButtons">
-                    <ng-container *ngIf="button.visible">
-                        <ng-container *ngTemplateOutlet="button.html ?? null">
+                        <ng-container *ngTemplateOutlet="filtersTmpl">
                         </ng-container>
                     </ng-container>
-                </ng-container>
-            </div>
 
-            <div #gridActionButtons
-                 *ngIf="hasSelection$ | async"
-                 class="ui-grid-action-buttons ui-grid-action-buttons-selection">
-                <ng-container *ngFor="let button of header?.actionButtons">
-                    <ng-container *ngIf="button.visible">
-                        <ng-container *ngTemplateOutlet="button.html?? null">
+                    <div *ngIf="!(hasSelection$ | async)"
+                        class="ui-grid-action-buttons ui-grid-action-buttons-inline">
+                        <ng-container *ngFor="let button of header?.inlineButtons">
+                            <ng-container *ngIf="button.visible">
+                                <ng-container *ngTemplateOutlet="button.html ?? null">
+                                </ng-container>
+                            </ng-container>
                         </ng-container>
-                    </ng-container>
+                    </div>
+
+                    <div #gridActionButtons
+                        *ngIf="hasSelection$ | async"
+                        class="ui-grid-action-buttons ui-grid-action-buttons-selection">
+                        <ng-container *ngFor="let button of header?.actionButtons">
+                            <ng-container *ngIf="button.visible">
+                                <ng-container *ngTemplateOutlet="button.html?? null">
+                                </ng-container>
+                            </ng-container>
+                        </ng-container>
+                    </div>
                 </ng-container>
-            </div>
+            </ng-template>
         </div>
         <div *ngIf="showFilters && (hasAnyFiltersVisible$ | async)"
              [@filters-container]

--- a/projects/angular/components/ui-grid/src/ui-grid.component.ts
+++ b/projects/angular/components/ui-grid/src/ui-grid.component.ts
@@ -79,6 +79,7 @@ import {
 import { ResizableGrid } from './managers/resize/types';
 import {
     GridOptions,
+    IFilterModel,
     ISortModel,
 } from './models';
 import { UiGridIntl } from './ui-grid.intl';
@@ -340,6 +341,15 @@ export class UiGridComponent<T extends { id: number | string }> extends Resizabl
     @Input()
     disableSelectionByEntry: (entry: T) => null | string;
 
+    @Input()
+    get customFilterValue() {
+        return this._customFilterValue;
+    }
+    set customFilterValue(customValue) {
+        if (!Array.isArray(customValue) || !customValue.length) { return; }
+        this.filterManager.updateCustomFilters(customValue);
+    }
+
     /**
      * Emits an event with the sort model when a column sort changes.
      *
@@ -367,6 +377,9 @@ export class UiGridComponent<T extends { id: number | string }> extends Resizabl
      */
     @Output()
     resizeEnd = new EventEmitter<void>();
+
+    @Output()
+    removeCustomFilter = new EventEmitter<void>();
 
     /**
      * Emits the column definitions when their definition changes.
@@ -604,6 +617,7 @@ export class UiGridComponent<T extends { id: number | string }> extends Resizabl
     private _isShiftPressed = false;
     private _lastCheckboxIdx = 0;
     private _resizeSubscription$: null | Subscription = null;
+    private _customFilterValue: IFilterModel<any>[] = [];
 
     /**
      * @ignore
@@ -891,6 +905,11 @@ export class UiGridComponent<T extends { id: number | string }> extends Resizabl
 
     focusRowHeader() {
         this.gridActionButtons?.nativeElement.querySelector(FOCUSABLE_ELEMENTS_QUERY)?.focus();
+    }
+
+    clearCustomFilter() {
+        this.removeCustomFilter.emit();
+        this.filterManager.clearCustomFilters();
     }
 
     private _announceGridHeaderActions() {

--- a/projects/angular/components/ui-grid/src/ui-grid.component.ts
+++ b/projects/angular/components/ui-grid/src/ui-grid.component.ts
@@ -342,10 +342,7 @@ export class UiGridComponent<T extends { id: number | string }> extends Resizabl
     disableSelectionByEntry: (entry: T) => null | string;
 
     @Input()
-    get customFilterValue() {
-        return this._customFilterValue;
-    }
-    set customFilterValue(customValue) {
+    set customFilterValue(customValue: IFilterModel<T>[]) {
         if (!Array.isArray(customValue) || !customValue.length) { return; }
         this.filterManager.updateCustomFilters(customValue);
     }
@@ -617,7 +614,6 @@ export class UiGridComponent<T extends { id: number | string }> extends Resizabl
     private _isShiftPressed = false;
     private _lastCheckboxIdx = 0;
     private _resizeSubscription$: null | Subscription = null;
-    private _customFilterValue: IFilterModel<any>[] = [];
 
     /**
      * @ignore

--- a/projects/angular/components/ui-grid/src/ui-grid.intl.ts
+++ b/projects/angular/components/ui-grid/src/ui-grid.intl.ts
@@ -109,6 +109,11 @@ export class UiGridIntl implements OnDestroy {
      */
     gridHeaderActionsNotice = 'Grid header actions updated. Press Shift + Alt + Arrow Up to move there.';
     /**
+     * Message for the button that clears the applied custom filter.
+     *
+     */
+    clearCustomFilter = 'Clear custom filter';
+    /**
      * No data row message alternative function.
      *
      */

--- a/projects/angular/package.json
+++ b/projects/angular/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@uipath/angular",
-    "version": "13.4.1",
+    "version": "13.5.0",
     "license": "MIT",
     "author": {
         "name": "UiPath Inc",

--- a/projects/angular/testing/src/utilities/fake-file-list.ts
+++ b/projects/angular/testing/src/utilities/fake-file-list.ts
@@ -27,6 +27,10 @@ export class FakeFileList implements FileList {
         });
     }
 
+    [Symbol.iterator](): IterableIterator<File> {
+        return this.files[Symbol.iterator]();
+    }
+
     /**
      * Retrieve an item at the specified index.
      *

--- a/projects/playground/src/app/pages/grid/component/grid.component.html
+++ b/projects/playground/src/app/pages/grid/component/grid.component.html
@@ -13,7 +13,8 @@
          [showPaintTime]="inputs.showPaintTime"
          [showHeaderRow]="inputs.showHeaderRow"
          [expandedEntry]="editedEntity"
-         [expandMode]="'preserve'">
+         [expandMode]="'preserve'"
+         [customFilterValue]="inputs.customFilter ? [{property: 'parity', method: 'eq', value: 'odd'}] : []">
 
     <ui-grid-header [search]="header.searchable">
         <ui-header-button *ngFor="let button of generateButtons(header.main)"

--- a/projects/playground/src/app/pages/grid/component/grid.component.ts
+++ b/projects/playground/src/app/pages/grid/component/grid.component.ts
@@ -26,6 +26,7 @@ import {
     ViewChild,
 } from '@angular/core';
 import {
+    IFilterModel,
     PageChangeEvent,
     UiGridComponent,
 } from '@uipath/angular/components/ui-grid';
@@ -90,14 +91,15 @@ export class GridComponent implements OnInit, OnDestroy, AfterViewInit {
             takeUntil(this._destroyed$),
         ).subscribe(([searchFilters, filters]) => {
             this.filteredData = cloneDeep(this.allData);
+            const filterValues = (filter: IFilterModel<any>) => {
+                this.filteredData = this.filteredData.filter((row: any) =>
+                row[filter.property]
+                    .toString()
+                    .includes(filter.value?.toString()));
+            };
 
-            searchFilters.forEach(filter => {
-                this.filteredData = this.filteredData.filter((row: any) => row[filter.property].includes(filter.value));
-            });
-
-            filters.forEach(filter => {
-                this.filteredData = this.filteredData.filter((row: any) => row[filter.property].includes(filter.value));
-            });
+            searchFilters.forEach(filterValues);
+            filters.forEach(filterValues);
 
             this.total = this.filteredData.length;
 

--- a/projects/playground/src/app/pages/grid/grid.models.ts
+++ b/projects/playground/src/app/pages/grid/grid.models.ts
@@ -27,4 +27,5 @@ export interface IInputs {
     virtualScroll: boolean;
     showPaintTime: boolean;
     showHeaderRow: boolean;
+    customFilter: boolean;
 }

--- a/projects/playground/src/app/pages/grid/grid.page.ts
+++ b/projects/playground/src/app/pages/grid/grid.page.ts
@@ -52,6 +52,7 @@ export class GridPageComponent implements AfterViewInit {
         'virtualScroll',
         'showPaintTime',
         'showHeaderRow',
+        'customFilter',
     ];
 
     buttonKeys = [
@@ -101,6 +102,7 @@ export class GridPageComponent implements AfterViewInit {
                 virtualScroll: [false],
                 showPaintTime: [false],
                 showHeaderRow: [true],
+                customFilter: [false],
             }),
             header: this._fb.group({
                 searchable: [true],

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -21,7 +21,8 @@
         ],
         "lib": [
             "es2018",
-            "dom"
+            "dom",
+            "dom.iterable"
         ],
         "paths": {
             "@uipath/angular/a11y": [


### PR DESCRIPTION
Creating a new input called `customFilterValue` which takes precedence over the usual filters. 
The output `removeCustomFilter` emits after pressing the "Clear custom filter"  button, then the custom filter is gone, and the usual filters are applied.
