### PR TITLE
feat(suggest): add compact summary support

### DIFF
--- a/projects/angular/components/ui-suggest/src/ui-suggest.component.html
+++ b/projects/angular/components/ui-suggest/src/ui-suggest.component.html
@@ -9,7 +9,7 @@
           Tested in NVDA.
       -->
 
-    <ng-container *ngIf="!multiple; else chipsTemplate">
+    <ng-container *ngIf="(!multiple || compact); else chipsTemplate">
         <div [attr.tabindex]="!disabled &&
                         !readonly ?
                         0 : null"
@@ -35,8 +35,7 @@
              matRipple
              class="display"
              role="combobox">
-            <ng-container
-                          *ngIf="itemTemplate && !multiple && value.length && displayTemplateValue; else showDefaultValue">
+            <ng-container *ngIf="itemTemplate && value.length && displayTemplateValue; else showDefaultValue">
                 <ng-container *ngTemplateOutlet="itemTemplate; context: {
                                                 $implicit: value[0]
                                             }">
@@ -50,10 +49,16 @@
                           aria-hidden="true">
                         {{ placeholder }}:
                     </span>
-                    <span class="display-value text-label-rendered">{{
-                        value[0]
-                        ? intl.translateLabel(value[0].text)
-                        : defaultValue }}</span>
+                    <ng-container *ngIf="compactSummaryTemplate; else defaultSummary">
+                        <ng-template #displayCompactSummaryTemplate
+                                     *ngTemplateOutlet="compactSummaryTemplate; context: { $implicit: value }">
+                        </ng-template>
+                    </ng-container>
+                    <ng-template #defaultSummary>
+                        <span class="display-value text-label-rendered">
+                            {{ computeDisplayValue() }}
+                        </span>
+                    </ng-template>
                 </div>
             </ng-template>
             <ng-container *ngIf="!readonly">
@@ -153,7 +158,7 @@
                 </ng-container>
             </ng-container>
 
-            <mat-form-field *ngIf="searchable && !multiple"
+            <mat-form-field *ngIf="searchable && (!multiple || compact)"
                             floatLabel="never">
                 <input #searchInput
                        [placeholder]="isFormControl ? '' : placeholder"
@@ -309,7 +314,6 @@
         </div>
     </mat-list-item>
 </ng-template>
-
 
 <ng-template #clearIcon>
     <mat-icon [matTooltip]="intl.clearSelectionLabel"

--- a/projects/angular/components/ui-suggest/src/ui-suggest.component.scss
+++ b/projects/angular/components/ui-suggest/src/ui-suggest.component.scss
@@ -187,6 +187,10 @@ $componentName: "ui-suggest";
         &-container {
             max-width: calc(100% - #{$mat-icon-size});
         }
+
+        .mat-icon {
+            flex-shrink: 0;
+        }
     }
 
     .mat-chip {

--- a/projects/angular/components/ui-suggest/src/ui-suggest.component.ts
+++ b/projects/angular/components/ui-suggest/src/ui-suggest.component.ts
@@ -309,7 +309,7 @@ export class UiSuggestComponent extends UiSuggestMatFormFieldDirective
             !this.isOpen &&
             this._hasValue
         ) {
-            return this.value.map(v => this.intl.translateLabel(v.text)).join(', ');
+            return this._getValueSummary();
         }
 
         return null;
@@ -1121,8 +1121,7 @@ export class UiSuggestComponent extends UiSuggestMatFormFieldDirective
 
     computeDisplayValue() {
         return this.value.length > 0
-            ? this.value.map(v => this.intl.translateLabel(v.text))
-                .join(',')
+            ? this._getValueSummary()
             : this.defaultValue;
     }
 
@@ -1405,5 +1404,9 @@ export class UiSuggestComponent extends UiSuggestMatFormFieldDirective
         UNSUPPORTED_SCENARIOS.forEach(({ errorText, scenario }) => {
             if (scenario) { throw new Error(errorText); }
         });
+    }
+
+    private _getValueSummary() {
+        this.value.map(v => this.intl.translateLabel(v.text)).join(', ');
     }
 }

--- a/projects/angular/components/ui-suggest/src/ui-suggest.component.ts
+++ b/projects/angular/components/ui-suggest/src/ui-suggest.component.ts
@@ -507,6 +507,20 @@ export class UiSuggestComponent extends UiSuggestMatFormFieldDirective
     disableTooltip = false;
 
     /**
+     * Use compact summary info instead of chips
+     *
+     */
+     @Input()
+     compact = false;
+
+     /**
+      * The template to use for compact summary
+      *
+      */
+     @Input()
+     compactSummaryTemplate?: TemplateRef<any>;
+
+    /**
      * Emits `once` when `data` is retrieved for the `first time`.
      *
      */
@@ -1103,6 +1117,13 @@ export class UiSuggestComponent extends UiSuggestMatFormFieldDirective
         if (!this.inputControl.value.trim().length) {
             this.close();
         }
+    }
+
+    computeDisplayValue() {
+        return this.value.length > 0
+            ? this.value.map(v => this.intl.translateLabel(v.text))
+                .join(',')
+            : this.defaultValue;
     }
 
     private _selectActiveItem(closeAfterSelect: boolean) {

--- a/projects/angular/components/ui-suggest/src/ui-suggest.component.ts
+++ b/projects/angular/components/ui-suggest/src/ui-suggest.component.ts
@@ -1407,6 +1407,6 @@ export class UiSuggestComponent extends UiSuggestMatFormFieldDirective
     }
 
     private _getValueSummary() {
-        this.value.map(v => this.intl.translateLabel(v.text)).join(', ');
+        return this.value.map(v => this.intl.translateLabel(v.text)).join(', ');
     }
 }

--- a/projects/playground/src/app/pages/suggest/suggest.page.html
+++ b/projects/playground/src/app/pages/suggest/suggest.page.html
@@ -24,3 +24,26 @@
                 [searchSourceFactory]="searchSourceFactory">
     </ui-suggest>
 </mat-form-field>
+
+<h2>Multiple select with compact summary instead of chips</h2>
+<mat-form-field>
+    <ui-suggest [searchable]="true"
+                [disabled]="false"
+                [multiple]="true"
+                [enableCustomValue]="true"
+                [searchSourceFactory]="searchSourceFactory"
+                [compact]="true"
+                [compactSummaryTemplate]="compactSummaryTemplate">
+    </ui-suggest>
+
+    <ng-template #compactSummaryTemplate
+                 let-value>
+        <div class="flex">
+            <span class="text-ellipsis">{{value?.[0]?.text}}</span>
+            <span *ngIf="(value?.length || 0) > 1"
+                  class="example-additional-selection">
+                (+{{(value?.length || 0) - 1}} {{value?.length === 2 ? 'other' : 'others'}})
+            </span>
+        </div>
+    </ng-template>
+</mat-form-field>

--- a/projects/playground/src/app/pages/suggest/suggest.page.html
+++ b/projects/playground/src/app/pages/suggest/suggest.page.html
@@ -26,6 +26,17 @@
 </mat-form-field>
 
 <h2>Multiple select with compact summary instead of chips</h2>
+<h3>With the default template</h3>
+<mat-form-field>
+    <ui-suggest [searchable]="true"
+                [disabled]="false"
+                [multiple]="true"
+                [enableCustomValue]="true"
+                [searchSourceFactory]="searchSourceFactory"
+                [compact]="true">
+    </ui-suggest>
+</mat-form-field>
+<h3>With custom template</h3>
 <mat-form-field>
     <ui-suggest [searchable]="true"
                 [disabled]="false"


### PR DESCRIPTION
Added a compact mode in order to display the multiselect summary as an alternative to chips
![image](https://user-images.githubusercontent.com/19292346/181274667-c8a2735a-b321-42cd-a163-ed0c22ae6cd0.png)

Solves: https://uipath.atlassian.net/browse/ACTV-15373