### PR TITLE
feat(grid): add column description icon

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# v13.6.1 (2022-08-04)
+* **grid** add column description icon
+* **grid** expose default filter values
+* **grid** add toggle columns divider
+
 # v13.6.0 (2022-07-28)
 * **fix** fix the return value of valueSummary func
 * **refactor** extract valueSummary func

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "angular-components",
-  "version": "13.6.0",
+  "version": "13.6.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "angular-components",
-  "version": "13.6.0",
+  "version": "13.6.1",
   "author": {
     "name": "UiPath Inc",
     "url": "https://uipath.com"

--- a/projects/angular/components/ui-grid/src/_ui-grid.theme.scss
+++ b/projects/angular/components/ui-grid/src/_ui-grid.theme.scss
@@ -174,6 +174,14 @@ $ui-grid-opacity-transition: opacity $ui-grid-default-transition;
                 transition: $ui-grid-default-transition;
             }
         }
+
+        .ui-grid-info-icon {
+            transition: $ui-grid-default-transition;
+            font-size: 16px;
+            display: flex;
+            justify-content: center;
+            align-items: center;
+        }
     }
 
     @include ui-grid-search-theme($theme);

--- a/projects/angular/components/ui-grid/src/body/ui-grid-column.directive.ts
+++ b/projects/angular/components/ui-grid/src/body/ui-grid-column.directive.ts
@@ -190,6 +190,9 @@ export class UiGridColumnDirective<T> implements OnChanges, OnDestroy {
     @Input()
     refetch = false;
 
+    @Input()
+    description = '';
+
     /**
      * The searchable dropdown directive reference.
      *

--- a/projects/angular/components/ui-grid/src/ui-grid.component.html
+++ b/projects/angular/components/ui-grid/src/ui-grid.component.html
@@ -154,11 +154,15 @@
                                     column.dropdown!.value!.value !== column.dropdown!.emptyStateValue) ||
                                     column.searchableDropdown?.value != null"
                                [matTooltip]="column.title ?? ''"
-                               [matTooltipDisabled]="resizeManager.isResizing">{{ column.title }}</p>
-                            <div *ngIf="column.sortable"
+                               [matTooltipDisabled]="resizeManager.isResizing"
+                               [attr.aria-label]="column.title + (column.description ? ('. ' + column.description) : '')">{{ column.title }}</p>
+                            <div *ngIf="column.sortable || column.description"
                                  [class.ui-grid-sort-indicator-asc]="column.sort === 'asc'"
                                  [class.ui-grid-sort-indicator-desc]="column.sort === 'desc'"
                                  class="ui-grid-sort-indicator">
+                                 <mat-icon *ngIf="column.description"
+                                           [matTooltip]="column.description"
+                                           class="ui-grid-info-icon material-icons-outlined">info</mat-icon>
                                 <mat-icon class="ui-grid-sort-icon">
                                     <svg xmlns="http://www.w3.org/2000/svg"
                                          viewBox="0 0 24 24">

--- a/projects/angular/components/ui-grid/src/ui-grid.component.spec.ts
+++ b/projects/angular/components/ui-grid/src/ui-grid.component.spec.ts
@@ -3737,4 +3737,71 @@ describe('Component: UiGrid', () => {
             .toEqual(fixture.componentInstance.filterValue.value);
         }));
     });
+
+    describe('Verify column description', () => {
+        @Component({
+            template: `
+                <ui-grid [data]="data"
+                         [customFilterValue]="customFilter">
+                    <ui-grid-column [property]="'myNumber'"
+                                    [sortable]="true"
+                                    [description]="columnDescription"
+                                    title="Number Header"
+                                    width="50%">
+                    </ui-grid-column>
+                </ui-grid>
+            `,
+        })
+        class TestFixtureCustomFilterGridComponent {
+            columnDescription = 'some column description';
+        }
+
+        let fixture: ComponentFixture<TestFixtureCustomFilterGridComponent>;
+
+        beforeEach(async () => {
+            TestBed.configureTestingModule({
+                imports: [
+                    UiGridModule,
+                    UiGridCustomPaginatorModule,
+                    NoopAnimationsModule,
+                ],
+                providers: [
+                    UiMatPaginatorIntl,
+                    {
+                        provide: UI_GRID_OPTIONS,
+                        useValue: {
+                            useLegacyDesign: false,
+                        },
+                    },
+                ],
+                declarations: [
+                    TestFixtureCustomFilterGridComponent,
+                ],
+            });
+
+            fixture = TestBed.createComponent(TestFixtureCustomFilterGridComponent);
+
+            fixture.detectChanges();
+            await fixture.whenStable();
+        });
+
+        afterEach(() => {
+            fixture.destroy();
+        });
+
+        it('should display info icon and change aria label attribute of the column', fakeAsync(() => {
+            fixture.detectChanges();
+            expect(document.querySelector('.ui-grid-info-icon ')).toBeTruthy();
+            const colTitleParagraphElement = document.querySelector('.ui-grid-header-title p');
+            expect(colTitleParagraphElement!.getAttribute('aria-label')).toEqual('Number Header. some column description');
+        }));
+
+        it('should not show info icon if description is missing', fakeAsync(() => {
+            fixture.componentInstance.columnDescription = '';
+            fixture.detectChanges();
+            expect(document.querySelector('.ui-grid-info-icon ')).toBeNull();
+            const colTitleParagraphElement = document.querySelector('.ui-grid-header-title p');
+            expect(colTitleParagraphElement!.getAttribute('aria-label')).toEqual('Number Header');
+        }));
+    });
 });

--- a/projects/angular/package.json
+++ b/projects/angular/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@uipath/angular",
-    "version": "13.6.0",
+    "version": "13.6.1",
     "license": "MIT",
     "author": {
         "name": "UiPath Inc",


### PR DESCRIPTION
Add `aria-label` to column headers in order to improve a11y.
Add new input `description` to `ui-grid-column` directive which inserts an info icon in the column header with the text in tooltip.