### PR TITLE
fix(grid): add toggle columns divider [OR-58318]

### DIFF
--- a/projects/angular/components/ui-grid/src/ui-grid.component.html
+++ b/projects/angular/components/ui-grid/src/ui-grid.component.html
@@ -586,7 +586,7 @@
                             [toggleTitle]="intl.toggleTitle"
                             [togglePlaceholderTitle]="intl.togglePlaceholderTitle"
                             [useLegacyDesign]="useLegacyDesign"
-                            [showDivider]="!useLegacyDesign && (hasAnyFiltersVisible$ | async) ?? false"
+                            [showDivider]="!useLegacyDesign && (displayToggleColumnsDivider$ | async) ?? false"
                             (visibleColumns)="visibilityManager.update($event)"
                             (resetColumns)="visibilityManager.reset()"
                             (visibleColumnsToggled)="visibleColumnsToggle$.next($event)">

--- a/projects/angular/components/ui-grid/src/ui-grid.component.ts
+++ b/projects/angular/components/ui-grid/src/ui-grid.component.ts
@@ -534,6 +534,12 @@ export class UiGridComponent<T extends { id: number | string }> extends Resizabl
     hasAnyFiltersVisible$: Observable<boolean>;
 
     /**
+     * Emits with information whether the dvider for toggle columns should be displayed
+     *
+     */
+    displayToggleColumnsDivider$?: Observable<boolean>;
+
+    /**
      * Emits the visible column definitions when their definition changes.
      *
      */
@@ -721,6 +727,8 @@ export class UiGridComponent<T extends { id: number | string }> extends Resizabl
         this._initResizeManager();
         this._performanceMonitor = new PerformanceMonitor(_ref.nativeElement);
         this.paintTime$ = this._performanceMonitor.paintTime$;
+
+        this._initDisplayToggleColumnsDivider();
     }
 
     /**
@@ -916,5 +924,11 @@ export class UiGridComponent<T extends { id: number | string }> extends Resizabl
         this._resizeSubscription$?.unsubscribe();
         this.resizeManager = ResizeManagerFactory(this._resizeStrategy, this);
         this._resizeSubscription$ = this.resizeManager.resizeEnd$.subscribe(() => this.resizeEnd.emit());
+    }
+
+    private _initDisplayToggleColumnsDivider() {
+        this.displayToggleColumnsDivider$ = combineLatest([this.hasAnyFiltersVisible$, this.filterManager.hasCustomFilter$]).pipe(
+            map(([hasAnyFilterVisible, hasCustomFilters]) => hasAnyFilterVisible || hasCustomFilters),
+        );
     }
 }


### PR DESCRIPTION
OR-58318

### Descritpion
---
Display toggle columns divider if the grid has filters or custom filter

Before change:
![image](https://user-images.githubusercontent.com/27362620/182601424-2f0a8955-c7e8-4d09-81e6-8ac1041ffe43.png)

After change:
![image](https://user-images.githubusercontent.com/27362620/182600559-b6d21251-01a4-4fe6-8602-9e041c547a6a.png)
