### PR TITLE
fix(dateformat): trigger change detection on setting input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# v13.6.7 (2022-08-18)
+* **dateformat** trigger change detection on setting input
+
 # v13.6.6 (2022-08-12)
 * **grid** hide expanded filters on row selection
 * **grid** hide custom filter btn on row selection

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "angular-components",
-  "version": "13.6.6",
+  "version": "13.6.7",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "angular-components",
-  "version": "13.6.6",
+  "version": "13.6.7",
   "author": {
     "name": "UiPath Inc",
     "url": "https://uipath.com"

--- a/projects/angular/directives/ui-dateformat/src/ui-dateformat.directive.ts
+++ b/projects/angular/directives/ui-dateformat/src/ui-dateformat.directive.ts
@@ -13,6 +13,7 @@ import {
 } from 'rxjs/operators';
 
 import {
+    ChangeDetectorRef,
     Directive,
     ElementRef,
     Inject,
@@ -132,7 +133,13 @@ export class UiDateFormatDirective extends UiFormatDirective {
      *
      */
     @Input()
-    date?: Date | string;
+    set date(date: Date | string | undefined) {
+        this._date = date;
+        this._cd.detectChanges();
+    }
+    get date() {
+        return this._date;
+    }
     /**
      * The `moment` format, defaults to `L LTS`.
      *
@@ -163,6 +170,7 @@ export class UiDateFormatDirective extends UiFormatDirective {
     private _lastRelativeTime?: string;
     private _lastContentType?: DisplayType;
     private _lastTitleType?: DisplayType;
+    private _date?: Date | string;
 
     /**
      * @ignore
@@ -171,6 +179,7 @@ export class UiDateFormatDirective extends UiFormatDirective {
         @Inject(UI_DATEFORMAT_OPTIONS)
         @Optional()
         private _options: IDateFormatOptions,
+        private _cd: ChangeDetectorRef,
         renderer: Renderer2,
         elementRef: ElementRef,
     ) {

--- a/projects/angular/package.json
+++ b/projects/angular/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@uipath/angular",
-    "version": "13.6.6",
+    "version": "13.6.7",
     "license": "MIT",
     "author": {
         "name": "UiPath Inc",


### PR DESCRIPTION
It is necessary to trigger a change detection when setting the `date` input in order to display the `matTooltip` on hovering