### PR TITLE
feat(grid): add new input queryProperty to UiGridColumnDirective 

### DIFF
--- a/projects/angular/components/ui-grid/src/body/ui-grid-column.directive.ts
+++ b/projects/angular/components/ui-grid/src/body/ui-grid-column.directive.ts
@@ -122,6 +122,13 @@ export class UiGridColumnDirective<T> implements OnChanges, OnDestroy {
     property?: keyof T | string; // nested property
 
     /**
+     * If defined, this will be used for sorting and filtering
+     *
+     */
+    @Input()
+    queryProperty?: keyof T | string; // nested property
+
+    /**
      * The method metadata used for searches.
      *
      */

--- a/projects/angular/components/ui-grid/src/managers/filter-manager.ts
+++ b/projects/angular/components/ui-grid/src/managers/filter-manager.ts
@@ -92,7 +92,7 @@ export class FilterManager<T> {
             this._columns
                 .filter(column => column.searchable)
                 .map(column => ({
-                    property: column.property,
+                    property: column.queryProperty ?? column.property,
                     value: term,
                     method: column.method,
                 })) as IFilterModel<T>[] :

--- a/projects/angular/components/ui-grid/src/managers/sort-manager.spec.ts
+++ b/projects/angular/components/ui-grid/src/managers/sort-manager.spec.ts
@@ -161,5 +161,38 @@ describe('Component: UiGrid', () => {
                 });
             });
         });
+
+        describe('State: doubled one column', () => {
+            let columns: UiGridColumnDirective<ITestEntity>[];
+
+            beforeEach(() => {
+                columns = generateColumnList('random');
+                columns.forEach(column => column.sortable = true);
+
+            });
+
+            it('should emit the reference property', (done) => {
+                const [firstColumn, duplicateColumn ] = columns;
+                firstColumn.property = 'prop1';
+                duplicateColumn.property = 'prop2';
+                duplicateColumn.queryProperty = 'prop1';
+                duplicateColumn.sort = 'desc';
+                manager.columns = columns;
+
+                manager.sort$
+                    .pipe(
+                        skip(1),
+                        take(1),
+                        finalize(done),
+                    ).subscribe(sort => {
+                        expect(sort.field).toEqual(duplicateColumn.queryProperty!);
+                        expect(sort.direction).toEqual(duplicateColumn.sort);
+                        expect(sort.userEvent).toBeTrue();
+                    });
+
+                manager.changeSort(duplicateColumn);
+            });
+        });
+
     });
 });

--- a/projects/angular/components/ui-grid/src/managers/sort-manager.ts
+++ b/projects/angular/components/ui-grid/src/managers/sort-manager.ts
@@ -70,7 +70,7 @@ export class SortManager<T> {
     private _emitSort(column: UiGridColumnDirective<T>, userEvent = false) {
         const updatedSort = {
             direction: column.sort,
-            field: column.property,
+            field: column.queryProperty ?? column.property,
             title: column.title,
             userEvent,
         } as ISortModel<T>;


### PR DESCRIPTION
Adding a new input `referenceProperty` to `UiGridColumnDirective` that takes precedence over `property` when sorting and filtering