### PR TITLE
feat: add initial workflow

### DIFF
--- a/.github/workflows/run-publish.yml
+++ b/.github/workflows/run-publish.yml
@@ -1,0 +1,27 @@
+name: Publish new version
+
+on:
+  workflow_dispatch:
+    inputs:
+      VersionBumpType:
+        type: choice
+        description: 'Version bump type'
+        required: true
+        options:
+        - patch
+        - minor
+        - major
+        - stable
+        - rc
+        - patch:rc
+        - minor:rc
+        - major:rc
+
+jobs:
+  test-job:
+    name: Log version-bump type
+    runs-on: ubuntu-latest
+    steps:
+      - name: Echo the version-bump type
+        run: |
+          echo ${{ github.event.inputs.VersionBumpType }}


### PR DESCRIPTION
A manually triggered Github action only shows up in the UI after it is merged in the main branch. Afterwards, however, you can select from which branch to use the action, and we can implement it on a new PR