### PR TITLE
fix(dateformat): call markForCheck only on initial assignment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# v13.12.4 (2022-11-22)
+* **dateformat** call markForCheck only on initial assignment markForCheck is needed so that changes propagate to matTooltip
+
 # v13.12.3 (2022-11-14)
 * **grid** expose resize stream
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "angular-components",
-  "version": "13.12.3",
+  "version": "13.12.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "angular-components",
-  "version": "13.12.3",
+  "version": "13.12.4",
   "author": {
     "name": "UiPath Inc",
     "url": "https://uipath.com"

--- a/projects/angular/directives/ui-dateformat/src/ui-dateformat.directive.spec.ts
+++ b/projects/angular/directives/ui-dateformat/src/ui-dateformat.directive.spec.ts
@@ -531,12 +531,12 @@ describe('Directive: UiDateFormat', () => {
             expect(momentOutputDate.minute()).toEqual(momentInputDate.minute());
         });
 
-        it('should call detectChanges if the date input value changes', fakeAsync(() => {
+        it('should call markForCheck if the date input value changes', fakeAsync(() => {
             fixture = TestBed.createComponent(TestHostComponent);
 
             component = fixture.componentInstance;
             const changeDetectorRef = (component.uiDateFormat as any)._cd;
-            const detectChangesSpy = spyOn(changeDetectorRef, 'markForCheck').and.callThrough();
+            const markForCheckSpy = spyOn(changeDetectorRef, 'markForCheck').and.callThrough();
 
             const now = Date.now();
 
@@ -562,7 +562,7 @@ describe('Directive: UiDateFormat', () => {
             tick(0);
             fixture.detectChanges();
 
-            expect(detectChangesSpy).toHaveBeenCalledTimes(1);
+            expect(markForCheckSpy).toHaveBeenCalledTimes(1);
             discardPeriodicTasks();
         }));
     });

--- a/projects/angular/directives/ui-dateformat/src/ui-dateformat.directive.spec.ts
+++ b/projects/angular/directives/ui-dateformat/src/ui-dateformat.directive.spec.ts
@@ -531,14 +531,16 @@ describe('Directive: UiDateFormat', () => {
             expect(momentOutputDate.minute()).toEqual(momentInputDate.minute());
         });
 
-        it('should call detectChanges if the date input value changes', () => {
+        it('should call detectChanges if the date input value changes', fakeAsync(() => {
             fixture = TestBed.createComponent(TestHostComponent);
 
             component = fixture.componentInstance;
             const changeDetectorRef = (component.uiDateFormat as any)._cd;
-            const detectChangesSpy = spyOn(changeDetectorRef, 'detectChanges').and.callThrough();
+            const detectChangesSpy = spyOn(changeDetectorRef, 'markForCheck').and.callThrough();
 
             const now = Date.now();
+
+            expect(component.date).toEqual(undefined);
 
             component.date = new Date(now);
             fixture.detectChanges();
@@ -557,10 +559,12 @@ describe('Directive: UiDateFormat', () => {
             fixture.detectChanges();
 
             component.date = undefined;
+            tick(0);
             fixture.detectChanges();
 
-            expect(detectChangesSpy).toHaveBeenCalledTimes(3);
-        });
+            expect(detectChangesSpy).toHaveBeenCalledTimes(1);
+            discardPeriodicTasks();
+        }));
     });
 
     describe('Configure inputs by setting injection token properties', () => {
@@ -585,7 +589,7 @@ describe('Directive: UiDateFormat', () => {
             component.date = momentInputDate.subtract(2, 'minutes').toDate();
 
             fixture.detectChanges();
-                const dateformatElement = fixture
+            const dateformatElement = fixture
                 .debugElement
                 .query(
                     By.css('ui-dateformat'),

--- a/projects/angular/directives/ui-dateformat/src/ui-dateformat.directive.ts
+++ b/projects/angular/directives/ui-dateformat/src/ui-dateformat.directive.ts
@@ -135,8 +135,15 @@ export class UiDateFormatDirective extends UiFormatDirective {
     @Input()
     set date(date: Date | string | undefined) {
         if (this._isDifferentValue(date, this._date)) {
+            const initial = this._date === undefined;
             this._date = date;
-            this._cd.detectChanges();
+
+            if (initial) {
+                // hack needed for initial render of mat-tooltip
+                // if not done only on initial may create a change detection loop
+                // seen on Edge ~107, cannot point to the exact root cause why
+                setTimeout(() => this._cd.markForCheck(), 0);
+            }
         }
     }
     get date() {

--- a/projects/angular/package.json
+++ b/projects/angular/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@uipath/angular",
-    "version": "13.12.3",
+    "version": "13.12.4",
     "license": "MIT",
     "author": {
         "name": "UiPath Inc",


### PR DESCRIPTION
markForCheck is needed so that changes propagate to matTooltip