### PR TITLE
Fix(keyboard-shortcut): require keys to be pressed again in order to emit again

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# v14.2.1 (2023-02-01)
+* **keyboard-shortcut** require keys to be pressed again
+
 # v14.2.0 (2023-01-30)
 * **grid** add icon on chips
 * **fix** version bump script

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "angular-components",
-  "version": "14.2.0",
+  "version": "14.2.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "angular-components",
-      "version": "14.2.0",
+      "version": "14.2.1",
       "license": "MIT",
       "dependencies": {
         "@angular/animations": "14.2.12",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "angular-components",
-  "version": "14.2.0",
+  "version": "14.2.1",
   "author": {
     "name": "UiPath Inc",
     "url": "https://uipath.com"

--- a/projects/angular/directives/keyboard-shortcut/src/keyboard-shortcut.directive.spec.ts
+++ b/projects/angular/directives/keyboard-shortcut/src/keyboard-shortcut.directive.spec.ts
@@ -15,10 +15,10 @@ import {
         <input
         uiKeyboardShortcut
         [shortcutKeys]="shortcuts"
-        (shortcutPressed)="shortcutWasPressed=true"/>`,
+        (shortcutPressed)="shortcutEmissionCounter=shortcutEmissionCounter+1"/>`,
 })
 class KeyboardShortcutTestFixtureComponent {
-    shortcuts = [['Control', 'a'], ['X', 'Y', 'Z']]; shortcutWasPressed = false;
+    shortcuts = [['Control', 'a'], ['X', 'Y', 'Z']]; shortcutEmissionCounter = 0;
 }
 
 describe('Directive: KeyboardShortcut', () => {
@@ -43,7 +43,21 @@ describe('Directive: KeyboardShortcut', () => {
         document.dispatchEvent(EventGenerator.keyDown(Key.a));
         document.dispatchEvent(EventGenerator.keyDown(Key.Control));
         fixture.detectChanges();
-        expect(fixture.componentInstance.shortcutWasPressed).toBeTruthy();
+        expect(fixture.componentInstance.shortcutEmissionCounter).toBeTruthy();
+    });
+
+    it('should not emit second time until all keys are released and pressed again', () => {
+        document.dispatchEvent(EventGenerator.keyDown(Key.a));
+        document.dispatchEvent(EventGenerator.keyDown(Key.Control));
+        fixture.detectChanges();
+        expect(fixture.componentInstance.shortcutEmissionCounter).toEqual(1);
+        document.dispatchEvent(EventGenerator.keyUp(Key.a));
+        document.dispatchEvent(EventGenerator.keyDown(Key.a));
+        fixture.detectChanges();
+        expect(fixture.componentInstance.shortcutEmissionCounter).toEqual(1);
+        document.dispatchEvent(EventGenerator.keyUp(Key.Control));
+        document.dispatchEvent(EventGenerator.keyDown(Key.Control));
+        expect(fixture.componentInstance.shortcutEmissionCounter).toEqual(2);
     });
 
     it('should not emit if key combination is not simultaneously pressed', () => {
@@ -54,6 +68,6 @@ describe('Directive: KeyboardShortcut', () => {
         document.dispatchEvent(EventGenerator.keyDown(Key.Z));
         fixture.detectChanges();
 
-        expect(fixture.componentInstance.shortcutWasPressed).toBeFalsy();
+        expect(fixture.componentInstance.shortcutEmissionCounter).toBeFalsy();
     });
 });

--- a/projects/angular/directives/keyboard-shortcut/src/keyboard-shortcut.directive.ts
+++ b/projects/angular/directives/keyboard-shortcut/src/keyboard-shortcut.directive.ts
@@ -32,6 +32,7 @@ export class KeyboardShortcutDirective {
         this._pressedKeys[event.key] = true;
         if (this.shortcutKeys.find(keyCombination => keyCombination.every(key => this._pressedKeys[key]))) {
             this.shortcutPressed.emit();
+            this._pressedKeys = {};
         }
     }
 

--- a/projects/angular/package.json
+++ b/projects/angular/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@uipath/angular",
-    "version": "14.2.0",
+    "version": "14.2.1",
     "license": "MIT",
     "author": {
         "name": "UiPath Inc",


### PR DESCRIPTION
when all the required keys for a shortcut are pressed simultaneously an event is emitted and the key pressed state is reset