### PR TITLE
Feat/custom value template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+# v14.3.0 (2023-02-08)
+* **playground** showcase custom value template support
+* **suggest** add custom value template support
+* **grid** take into account noDateMessage
+* **deps** bump jszip from 3.7.1 to 3.10.1
+* **deps** bump http-cache-semantics from 4.1.0 to 4.1.1
+* **deps** bump json5 from 1.0.1 to 1.0.2
+* **deps** bump qs from 6.5.2 to 6.5.3
+* **deps-dev** bump json from 9.0.6 to 10.0.0
+* **deps** bump ua-parser-js from 0.7.31 to 0.7.33
+
 # v14.2.1 (2023-02-01)
 * **keyboard-shortcut** require keys to be pressed again
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "angular-components",
-  "version": "14.2.1",
+  "version": "14.3.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "angular-components",
-      "version": "14.2.1",
+      "version": "14.3.0",
       "license": "MIT",
       "dependencies": {
         "@angular/animations": "14.2.12",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "angular-components",
-  "version": "14.2.1",
+  "version": "14.3.0",
   "author": {
     "name": "UiPath Inc",
     "url": "https://uipath.com"

--- a/projects/angular/components/ui-suggest/src/ui-suggest.component.html
+++ b/projects/angular/components/ui-suggest/src/ui-suggest.component.html
@@ -322,16 +322,27 @@
              : customValueLabelTranslator(inputControl.value) as customValueText">
         <mat-list-item *ngIf="isCustomValueVisible && direction === renderDirection"
                        [class.active]="(renderDirection === 'down' ? -1 : items.length) === activeIndex"
+                       [class.custom-value-template]="itemTemplate && applyItemTemplateToCustomValue"
                        [matTooltip]="customValueText"
                        [style.height.px]="itemSize"
                        (click)="preventDefault($event); updateValue(inputControl.value, !multiple, true);"
                        [attr.role]="'option'"
                        matTooltipPosition="right"
                        class="text-ellipsis custom-item">
-            <div class="text-label text-ellipsis">
-                <mat-icon *ngIf="!isCustomValueAlreadySelected">add</mat-icon>
-                <span class="text-label-rendered">{{ customValueText }}</span>
-            </div>
+            <ng-container *ngTemplateOutlet="itemTemplate && applyItemTemplateToCustomValue ? itemTemplate : defaultCustomValueTemplate; context: {
+                    $implicit: customValueText,
+                    isCustomValue: true,
+                    isCustomValueAlreadySelected
+                }">
+            </ng-container>
+
+            <ng-template #defaultCustomValueTemplate
+                         let-customValueText>
+                <div class="text-label text-ellipsis">
+                    <mat-icon *ngIf="!isCustomValueAlreadySelected">add</mat-icon>
+                    <span class="text-label-rendered">{{ customValueText }}</span>
+                </div>
+            </ng-template>
         </mat-list-item>
     </ng-container>
 </ng-template>

--- a/projects/angular/components/ui-suggest/src/ui-suggest.component.scss
+++ b/projects/angular/components/ui-suggest/src/ui-suggest.component.scss
@@ -129,7 +129,7 @@ $componentName: "ui-suggest";
             &-item {
                 cursor: pointer;
 
-                &.text-ellipsis .mat-list-item-content {
+                &.text-ellipsis:not(.custom-value-template) .mat-list-item-content {
                     display: block;
                 }
 

--- a/projects/angular/components/ui-suggest/src/ui-suggest.component.ts
+++ b/projects/angular/components/ui-suggest/src/ui-suggest.component.ts
@@ -189,6 +189,13 @@ export class UiSuggestComponent extends UiSuggestMatFormFieldDirective
     ignoreOpenOnFetch = false;
 
     /**
+     * Controls whether to use the default custom value template or use the custom item template
+     *
+     */
+    @Input()
+    applyItemTemplateToCustomValue = false;
+
+    /**
      * A list of options that will be presented at the top of the list.
      *
      */

--- a/projects/angular/package.json
+++ b/projects/angular/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@uipath/angular",
-    "version": "14.2.1",
+    "version": "14.3.0",
     "license": "MIT",
     "author": {
         "name": "UiPath Inc",

--- a/projects/playground/src/app/pages/suggest/suggest.page.html
+++ b/projects/playground/src/app/pages/suggest/suggest.page.html
@@ -13,6 +13,32 @@
     </ui-suggest>
 </mat-form-field>
 
+<h1>Custom value custom template</h1>
+<mat-form-field>
+    <ui-suggest [fetchStrategy]="'onOpen'"
+                [enableCustomValue]="true"
+                [applyItemTemplateToCustomValue]="true"
+                [customItemSize]="60"
+                [searchSourceFactory]="searchSourceFactory">
+        <ng-template let-item
+                     let-isCustomValue="isCustomValue"
+                     let-isCustomValueAlreadySelected="isCustomValueAlreadySelected">
+
+            <ng-container *ngIf="!isCustomValue">
+                {{item.text}}
+            </ng-container>
+
+            <ng-container *ngIf="isCustomValue && !isCustomValueAlreadySelected">
+                + Add {{item}}
+            </ng-container>
+
+            <ng-container *ngIf="isCustomValue && isCustomValueAlreadySelected">
+                Value already selected
+            </ng-container>
+        </ng-template>
+    </ui-suggest>
+</mat-form-field>
+
 <hr class="spacer">
 
 <h2>Multiple select suggest</h2>


### PR DESCRIPTION
### Feature description

Adds `applyItemTemplateToCustomValue` input which allows the user to control to switch between the default custom value template or sharing the provided `itemTemplate`

### Usage

- set `applyItemTemplateToCustomValue`
- in template you have access to `isCustomValue` to determine whether the current item is existing or a custom value
- you also have access to `isCustomValueAlreadySelected` to determine whether the current custom value is currently selected or not
- note that by default the item passed via context for an existing item will be the item's data, while for a custom value it will be the value of the input 

```javascript
<ui-suggest [enableCustomValue]="true"
            [applyItemTemplateToCustomValue]="true"
            ... >
     <ng-template let-item
                  let-isCustomValue="isCustomValue"
                  let-isCustomValueAlreadySelected="isCustomValueAlreadySelected">

        <ng-container *ngIf="!isCustomValue">
            {{item.text}}
        </ng-container>

        <ng-container *ngIf="isCustomValue && !isCustomValueAlreadySelected">
            + Add {{item}}
        </ng-container>

        <ng-container *ngIf="isCustomValue && isCustomValueAlreadySelected">
            Value already selected
        </ng-container>
    </ng-template>
</ui-suggest>
```