### PR TITLE
fix: luxon formatting in tooltips

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# v14.4.0 (2023-02-13)
+* **dateformat** fixes default luxon formatting
+
 # v14.3.0 (2023-02-08)
 * **playground** showcase custom value template support
 * **suggest** add custom value template support

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "angular-components",
-  "version": "14.3.0",
+  "version": "14.4.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "angular-components",
-      "version": "14.3.0",
+      "version": "14.4.0",
       "license": "MIT",
       "dependencies": {
         "@angular/animations": "14.2.12",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "angular-components",
-  "version": "14.3.0",
+  "version": "14.4.0",
   "author": {
     "name": "UiPath Inc",
     "url": "https://uipath.com"

--- a/projects/angular/directives/ui-dateformat/src/ui-dateformat.directive.ts
+++ b/projects/angular/directives/ui-dateformat/src/ui-dateformat.directive.ts
@@ -180,7 +180,7 @@ export class UiDateFormatDirective extends UiFormatDirective {
     }
     /**
      * The 'moment' format defaults to 'L LTS'.
-     * The `luxon` format defaults to `DateTime.DATETIME_SHORT.
+     * The `luxon` format defaults to `DateTime.DATETIME_SHORT_WITH_SECONDS.
      *
      */
     @Input()
@@ -192,11 +192,11 @@ export class UiDateFormatDirective extends UiFormatDirective {
         if (!this.date) { return ''; }
         if (!(this.date instanceof Date)) { return this.date; }
 
-        const relativeTime = this._isMomentFormat(this.dateFormat)
-            ? moment(this.date)
-                .fromNow()
-            : DateTime.fromJSDate(this.date)
-                .toRelative();
+        const relativeTime = this._useLuxon
+            ? DateTime.fromJSDate(this.date)
+                .toRelative()
+            : moment(this.date)
+                .fromNow();
 
         return relativeTime ?? '';
     }
@@ -244,7 +244,7 @@ export class UiDateFormatDirective extends UiFormatDirective {
             elementRef,
         );
 
-        const defaultFormat = this._useLuxon ? DateTime.DATETIME_SHORT : 'L LTS';
+        const defaultFormat = this._useLuxon ? DateTime.DATETIME_SHORT_WITH_SECONDS : 'L LTS';
 
         this._options = _options || {};
         this.dateFormat = this._options.format ?? defaultFormat;

--- a/projects/angular/package.json
+++ b/projects/angular/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@uipath/angular",
-    "version": "14.3.0",
+    "version": "14.4.0",
     "license": "MIT",
     "author": {
         "name": "UiPath Inc",


### PR DESCRIPTION
Fixes some default formatting issues:

- Absolute time tooltip now contains seconds
- Relatve time tooltip is now correctly using Luxon