### PR TITLE
fix: dateformat luxon absolute time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# v14.4.1 (2023-02-15)
+* **dateformat** use luxon for absolute time if enabled
+
 # v14.4.0 (2023-02-13)
 * **dateformat** fixes default luxon formatting
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "angular-components",
-  "version": "14.4.0",
+  "version": "14.4.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "angular-components",
-      "version": "14.4.0",
+      "version": "14.4.1",
       "license": "MIT",
       "dependencies": {
         "@angular/animations": "14.2.12",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "angular-components",
-  "version": "14.4.0",
+  "version": "14.4.1",
   "author": {
     "name": "UiPath Inc",
     "url": "https://uipath.com"

--- a/projects/angular/directives/ui-dateformat/src/ui-dateformat.directive.ts
+++ b/projects/angular/directives/ui-dateformat/src/ui-dateformat.directive.ts
@@ -1,8 +1,8 @@
 import 'moment-timezone';
 
 import {
- DateTime,
- DateTimeFormatOptions,
+    DateTime,
+    DateTimeFormatOptions,
 } from 'luxon';
 import moment from 'moment';
 import {
@@ -205,15 +205,15 @@ export class UiDateFormatDirective extends UiFormatDirective {
         if (!this.date) { return ''; }
         if (!(this.date instanceof Date)) { return this.date; }
 
-        const absoluteTime = this._isMomentFormat(this.dateFormat)
-            ? moment(this.date)
+        let absoluteTime;
+
+        if (this._useLuxon) {
+            absoluteTime = this._luxonAbsoluteTime(this.date);
+        } else if (this._isStringFormat(this.dateFormat)) {
+            absoluteTime = moment(this.date)
                 .tz(this.timezone ?? resolveTimezone(this._options))
-                .format(this.dateFormat)
-            : DateTime
-                .fromJSDate(this.date, {
-                    zone: this.timezone ?? resolveTimezone(this._options),
-                })
-                .toLocaleString(this.dateFormat);
+                .format(this.dateFormat);
+        }
 
         return absoluteTime ?? '';
     }
@@ -304,7 +304,7 @@ export class UiDateFormatDirective extends UiFormatDirective {
         this._renderer.setAttribute(this._elementRef.nativeElement, 'data-title', this._timeForType(this.titleType));
     }
 
-    private _isMomentFormat(format: string | DateTimeFormatOptions): format is string {
+    private _isStringFormat(format: string | DateTimeFormatOptions): format is string {
         return typeof format === 'string';
     }
 
@@ -326,4 +326,15 @@ export class UiDateFormatDirective extends UiFormatDirective {
 
         return value !== compareValue;
     };
+
+    private _luxonAbsoluteTime(date: Date) {
+        const time = DateTime
+        .fromJSDate(date, {
+            zone: this.timezone ?? resolveTimezone(this._options),
+        });
+
+        return this._isStringFormat(this.dateFormat)
+            ? time.toFormat(this.dateFormat)
+            : time.toLocaleString(this.dateFormat);
+    }
 }

--- a/projects/angular/package.json
+++ b/projects/angular/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@uipath/angular",
-    "version": "14.4.0",
+    "version": "14.4.1",
     "license": "MIT",
     "author": {
         "name": "UiPath Inc",


### PR DESCRIPTION
When computing absolute time, if `luxon` was enabled and `dateFormat` was a `string`, we would still use `moment`.