### PR TITLE
Fix: display concatenated tooltip (title + description) on keyboard focus

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# v14.5.3 (2023-03-03)
+* **grid** add test for tooltip on focus
+* **grid** display title & description tooltip on focus
+
 # v14.5.2 (2023-03-01)
 * **grid** display sort icon correctly
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "angular-components",
-  "version": "14.5.2",
+  "version": "14.5.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "angular-components",
-      "version": "14.5.2",
+      "version": "14.5.3",
       "license": "MIT",
       "dependencies": {
         "@angular/animations": "14.2.12",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "angular-components",
-  "version": "14.5.2",
+  "version": "14.5.3",
   "author": {
     "name": "UiPath Inc",
     "url": "https://uipath.com"

--- a/projects/angular/components/ui-grid/src/ui-grid.component.html
+++ b/projects/angular/components/ui-grid/src/ui-grid.component.html
@@ -139,7 +139,6 @@
 
                     <ng-container *ngIf="multiPageSelect then multiPageSelectionProjectedHeaderCell">
                     </ng-container>
-
                     <div *ngFor="let column of visible$ | async; let last = last; let columnIndex = index"
                          [class.ui-grid-header-cell-sortable]="column.sortable"
                          [class.ui-grid-resizeable]="column.resizeable"
@@ -148,19 +147,24 @@
                          [attr.data-property]="column.property"
                          [attr.data-identifier]="column.identifier"
                          [style.width.%]="column.width"
+                         (cdkFocusChange)="triggerColumnHeaderTooltip($event, columnTooltip)"
+                         (focusout)="hideColumnHeaderTooltip(columnTooltip)"
                          (keyup.enter)="sortManager.changeSort(column)"
                          (keyup.space)="sortManager.changeSort(column)"
                          (keydown.ArrowLeft)="!last && resizeManager.startKeyboardResize('left', column, columnIndex)"
                          (keydown.ArrowRight)="!last && resizeManager.startKeyboardResize('right', column, columnIndex)"
+                         cdkMonitorElementFocus
                          class="ui-grid-header-cell"
                          role="columnheader"
                          tabindex="0">
                         <div (click)="sortManager.changeSort(column)"
                              class="ui-grid-header-title">
-                            <p [class.ui-grid-header-title-filtered]="isFilterApplied(column)"
-                               [matTooltip]="column.title ?? ''"
+                            <p #columnTooltip="matTooltip"
+                               [class.ui-grid-header-title-filtered]="isFilterApplied(column)"
+                               [matTooltip]="column.title + (focusedColumnHeader ? ('\n' + column.description) : '')"
                                [matTooltipDisabled]="resizeManager.isResizing"
-                               [attr.aria-label]="column.title + (column.description ? ('. ' + column.description) : '') + (column.sortable && intl.sortableMessage ? '. ' + intl.sortableMessage : '')">
+                               [attr.aria-label]="column.title + (column.description ? ('. ' + column.description) : '') + (column.sortable && intl.sortableMessage ? '. ' + intl.sortableMessage : '')"
+                               matTooltipClass="preserve-whitespace">
                                 {{ column.title }}</p>
 
                             <mat-icon *ngIf="column.description"

--- a/projects/angular/components/ui-grid/src/ui-grid.component.scss
+++ b/projects/angular/components/ui-grid/src/ui-grid.component.scss
@@ -1,5 +1,11 @@
 @import "../../styles/ellipse";
 
+.preserve-whitespace {
+    word-wrap: break-word;
+    white-space: pre-line;
+    text-align: left;
+}
+
 ui-grid {
     $ui-grid-header-row-height: 56px;
     $ui-grid-header-alternate-row-height: 52px;

--- a/projects/angular/components/ui-grid/src/ui-grid.component.spec.ts
+++ b/projects/angular/components/ui-grid/src/ui-grid.component.spec.ts
@@ -285,6 +285,33 @@ describe('Component: UiGrid', () => {
                     expect(Math.round(initialCol1Width + initialCol2Width)).toEqual(Math.round(newCol1Width + newCol2Width));
                     discardPeriodicTasks();
                 }));
+
+                it('should show tooltip on keyboard focus and hide it on focusout', fakeAsync(() => {
+                    const spyTriggerTooltip = spyOn(grid, 'triggerColumnHeaderTooltip').and.callThrough();
+                    const spyHideTooltip = spyOn(grid, 'hideColumnHeaderTooltip').and.callThrough();
+                    const event = new KeyboardEvent('keydown', { key: 'Tab' });
+                    const focusEvent = new FocusEvent('focus', { bubbles: true });
+                    const focusOutEvent = new FocusEvent('focusout', { bubbles: true });
+                    const [columnHeader1, columnHeader2 ] = document.querySelectorAll('div[role="columnheader"]')!;
+
+                    columnHeader1.dispatchEvent(event);
+                    fixture.detectChanges();
+
+                    columnHeader1.dispatchEvent(focusEvent);
+                    fixture.detectChanges();
+                    tick(500);
+
+                    const tooltip = document.querySelectorAll('.preserve-whitespace');
+                    expect(tooltip).toBeTruthy();
+                    expect(spyTriggerTooltip).toHaveBeenCalled();
+
+                    columnHeader2.dispatchEvent(focusOutEvent);
+                    fixture.detectChanges();
+                    tick(500);
+
+                    expect(spyHideTooltip).toHaveBeenCalled();
+                    discardPeriodicTasks();
+                }));
             });
 
             describe('State: populated', () => {

--- a/projects/angular/components/ui-grid/src/ui-grid.component.ts
+++ b/projects/angular/components/ui-grid/src/ui-grid.component.ts
@@ -30,6 +30,7 @@ import {
     transition,
     trigger,
 } from '@angular/animations';
+import { FocusOrigin } from '@angular/cdk/a11y';
 import {
     AfterContentInit,
     ChangeDetectionStrategy,
@@ -57,6 +58,7 @@ import {
     MatCheckbox,
     MatCheckboxChange,
 } from '@angular/material/checkbox';
+import { MatTooltip } from '@angular/material/tooltip';
 import { QueuedAnnouncer } from '@uipath/angular/a11y';
 import { ISuggestValue } from '@uipath/angular/components/ui-suggest';
 
@@ -65,8 +67,8 @@ import { UiGridExpandedRowDirective } from './body/ui-grid-expanded-row.directiv
 import { UiGridLoadingDirective } from './body/ui-grid-loading.directive';
 import { UiGridNoContentDirective } from './body/ui-grid-no-content.directive';
 import { UiGridRowActionDirective } from './body/ui-grid-row-action.directive';
-import { UiGridRowConfigDirective } from './body/ui-grid-row-config.directive';
 import { UiGridRowCardViewDirective } from './body/ui-grid-row-card-view.directive';
+import { UiGridRowConfigDirective } from './body/ui-grid-row-config.directive';
 import { UiGridSearchFilterDirective } from './filters/ui-grid-search-filter.directive';
 import { UiGridFooterDirective } from './footer/ui-grid-footer.directive';
 import { UiGridHeaderDirective } from './header/ui-grid-header.directive';
@@ -621,6 +623,12 @@ export class UiGridComponent<T extends IGridDataEntry> extends ResizableGrid<T> 
     scrollCompensationWidth = 0;
 
     /**
+     * Whether column header is focused.
+     *
+     */
+    focusedColumnHeader = false;
+
+    /**
      * @internal
      * @ignore
      */
@@ -1041,6 +1049,18 @@ export class UiGridComponent<T extends IGridDataEntry> extends ResizableGrid<T> 
     isFilterApplied(column: UiGridColumnDirective<T>) {
         return (column.dropdown?.value != null && column.dropdown!.value!.value !== column.dropdown!.emptyStateValue)
             || (column.searchableDropdown?.value != null && (column.searchableDropdown?.value as ISuggestValue[])?.length !== 0);
+    }
+
+    triggerColumnHeaderTooltip(event: FocusOrigin, tooltip: MatTooltip) {
+        if (event === 'keyboard') {
+            this.focusedColumnHeader = true;
+            tooltip.show();
+        }
+    }
+
+    hideColumnHeaderTooltip(tooltip: MatTooltip) {
+        tooltip.hide();
+        this.focusedColumnHeader = false;
     }
 
     private _announceGridHeaderActions() {

--- a/projects/angular/package.json
+++ b/projects/angular/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@uipath/angular",
-    "version": "14.5.2",
+    "version": "14.5.3",
     "license": "MIT",
     "author": {
         "name": "UiPath Inc",


### PR DESCRIPTION
When the column header is focused it should display a tooltip that consists of the concatenation of column title and column description.
Demo: 


https://user-images.githubusercontent.com/87014385/222734741-12d3ef1b-e2c2-4f30-9337-0d36b061baab.mp4


