### PR TITLE
[v14.5] fix: humanize duration in different locales

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# v14.5.5 (2023-03-31)
+* **fix** humanize duration in different locales
+
 # v14.5.3 (2023-03-03)
 * **grid** add test for tooltip on focus
 * **grid** display title & description tooltip on focus

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "angular-components",
-  "version": "14.5.3",
+  "version": "14.5.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "angular-components",
-      "version": "14.5.3",
+      "version": "14.5.4",
       "license": "MIT",
       "dependencies": {
         "@angular/animations": "14.2.12",
@@ -20,7 +20,6 @@
         "@angular/platform-browser-dynamic": "14.2.12",
         "@angular/router": "14.2.12",
         "clipboard": "2.0.8",
-        "humanize-duration": "3.28.0",
         "lodash-es": "4.17.21",
         "luxon": "3.2.1",
         "moment": "2.29.4",
@@ -51,7 +50,6 @@
         "@types/chalk": "^2.2.0",
         "@types/clipboard": "2.0.7",
         "@types/faker": "4.1.5",
-        "@types/humanize-duration": "3.27.1",
         "@types/jasmine": "3.3.12",
         "@types/jasmine_dom_matchers": "^1.4.4",
         "@types/jasminewd2": "2.0.6",
@@ -5447,12 +5445,6 @@
       "dependencies": {
         "@types/node": "*"
       }
-    },
-    "node_modules/@types/humanize-duration": {
-      "version": "3.27.1",
-      "resolved": "https://registry.npmjs.org/@types/humanize-duration/-/humanize-duration-3.27.1.tgz",
-      "integrity": "sha512-K3e+NZlpCKd6Bd/EIdqjFJRFHbrq5TzPPLwREk5Iv/YoIjQrs6ljdAUCo+Lb2xFlGNOjGSE0dqsVD19cZL137w==",
-      "dev": true
     },
     "node_modules/@types/jasmine": {
       "version": "3.3.12",
@@ -14364,11 +14356,6 @@
       "engines": {
         "node": ">=10.17.0"
       }
-    },
-    "node_modules/humanize-duration": {
-      "version": "3.28.0",
-      "resolved": "https://registry.npmjs.org/humanize-duration/-/humanize-duration-3.28.0.tgz",
-      "integrity": "sha512-jMAxraOOmHuPbffLVDKkEKi/NeG8dMqP8lGRd6Tbf7JgAeG33jjgPWDbXXU7ypCI0o+oNKJFgbSB9FKVdWNI2A=="
     },
     "node_modules/humanize-ms": {
       "version": "1.2.1",
@@ -29583,12 +29570,6 @@
         "@types/node": "*"
       }
     },
-    "@types/humanize-duration": {
-      "version": "3.27.1",
-      "resolved": "https://registry.npmjs.org/@types/humanize-duration/-/humanize-duration-3.27.1.tgz",
-      "integrity": "sha512-K3e+NZlpCKd6Bd/EIdqjFJRFHbrq5TzPPLwREk5Iv/YoIjQrs6ljdAUCo+Lb2xFlGNOjGSE0dqsVD19cZL137w==",
-      "dev": true
-    },
     "@types/jasmine": {
       "version": "3.3.12",
       "resolved": "https://registry.npmjs.org/@types/jasmine/-/jasmine-3.3.12.tgz",
@@ -36406,11 +36387,6 @@
       "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
       "integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==",
       "dev": true
-    },
-    "humanize-duration": {
-      "version": "3.28.0",
-      "resolved": "https://registry.npmjs.org/humanize-duration/-/humanize-duration-3.28.0.tgz",
-      "integrity": "sha512-jMAxraOOmHuPbffLVDKkEKi/NeG8dMqP8lGRd6Tbf7JgAeG33jjgPWDbXXU7ypCI0o+oNKJFgbSB9FKVdWNI2A=="
     },
     "humanize-ms": {
       "version": "1.2.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "angular-components",
-  "version": "14.5.4",
+  "version": "14.5.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "angular-components",
-      "version": "14.5.4",
+      "version": "14.5.5",
       "license": "MIT",
       "dependencies": {
         "@angular/animations": "14.2.12",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "angular-components",
-  "version": "14.5.4",
+  "version": "14.5.5",
   "author": {
     "name": "UiPath Inc",
     "url": "https://uipath.com"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "angular-components",
-  "version": "14.5.3",
+  "version": "14.5.4",
   "author": {
     "name": "UiPath Inc",
     "url": "https://uipath.com"
@@ -81,7 +81,6 @@
     "@angular/platform-browser-dynamic": "14.2.12",
     "@angular/router": "14.2.12",
     "clipboard": "2.0.8",
-    "humanize-duration": "3.28.0",
     "lodash-es": "4.17.21",
     "luxon": "3.2.1",
     "moment": "2.29.4",
@@ -112,7 +111,6 @@
     "@types/chalk": "^2.2.0",
     "@types/clipboard": "2.0.7",
     "@types/faker": "4.1.5",
-    "@types/humanize-duration": "3.27.1",
     "@types/jasmine": "3.3.12",
     "@types/jasmine_dom_matchers": "^1.4.4",
     "@types/jasminewd2": "2.0.6",

--- a/projects/angular/directives/ui-dateformat/src/ui-dateformat.directive.ts
+++ b/projects/angular/directives/ui-dateformat/src/ui-dateformat.directive.ts
@@ -112,7 +112,6 @@ export const resolveTimezone = (options: IDateFormatOptions) => {
  * Optionally, you can opt-in to use Luxon instead of Moment.
  * Depends On:
  * - [luxon](https://www.npmjs.com/package/luxon)
- * - [humanize-duration](https://www.npmjs.com/package/humanize-duration)
  *
  * @export
  */

--- a/projects/angular/directives/ui-secondformat/src/ui-secondformat.directive.luxon.spec.ts
+++ b/projects/angular/directives/ui-secondformat/src/ui-secondformat.directive.luxon.spec.ts
@@ -1,3 +1,4 @@
+import { Settings } from 'luxon';
 import {
     BehaviorSubject,
     firstValueFrom,
@@ -13,9 +14,8 @@ import {
     waitForAsync,
 } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
-
-import { Settings } from 'luxon';
 import { USE_LUXON } from '@uipath/angular/utilities';
+
 import {
     ISecondFormatOptions,
     UiSecondFormatDirective,
@@ -159,6 +159,37 @@ describe('Directive: UiSecondFormat with luxon', () => {
             expect(text.nativeElement.innerText).toBe('40 秒');
             const jaTooltip = await firstValueFrom(component.uiSecondFormat.tooltip$);
             expect(enTooltip).toBe(jaTooltip);
+        });
+    });
+
+    describe('humanize in different locales', () => {
+        [
+            {
+                code: 'es-mx',
+                unit: ' segundos',
+            },
+            {
+                code: 'pt-br',
+                unit: ' segundos',
+            },
+            {
+                code: 'zh-cn',
+                unit: '秒钟',
+            },
+        ].forEach(locale => {
+            it(`should humanize in ${locale.code}`, async () => {
+                Settings.defaultLocale = locale.code;
+
+                component.seconds = 40;
+                fixture.detectChanges();
+
+                const text = fixture.debugElement.query(By.directive(UiSecondFormatDirective));
+
+                (options.redraw$ as BehaviorSubject<void>).next();
+
+                fixture.detectChanges();
+                expect(text.nativeElement.innerText).toBe(`40${locale.unit}`);
+            });
         });
     });
 });

--- a/projects/angular/package.json
+++ b/projects/angular/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@uipath/angular",
-    "version": "14.5.4",
+    "version": "14.5.5",
     "license": "MIT",
     "author": {
         "name": "UiPath Inc",

--- a/projects/angular/package.json
+++ b/projects/angular/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@uipath/angular",
-    "version": "14.5.3",
+    "version": "14.5.4",
     "license": "MIT",
     "author": {
         "name": "UiPath Inc",
@@ -39,7 +39,6 @@
         "@angular/platform-browser-dynamic": ">=14.1.0",
         "@angular/router": ">=14.1.0",
         "clipboard": "^2.0.8",
-        "humanize-duration": "^3.28.0",
         "lodash-es": "^4.17.21",
         "luxon": "^3.2.1",
         "moment": "^2.29.1",


### PR DESCRIPTION
Dropped `humanize-duration`, as it doesn't handle all our supported locales.

For our specific case here, we can rely on luxon only, by finding the largest unit of the duration, creating a new one from it and then calling `toHuman`.

If we don't search for the largest unit, luxon would return all units in the humanized string.