### PR TITLE
fix(suggest): fix focus logic when navigating with TAB

### DIFF
--- a/projects/angular/components/ui-grid/src/ui-grid.component.scss
+++ b/projects/angular/components/ui-grid/src/ui-grid.component.scss
@@ -321,10 +321,7 @@ ui-grid {
             justify-content: center;
             display: flex;
             align-items: center;
-
-            mat-icon {
-                margin-right: $ui-grid-default-spacing;
-            }
+            margin-right: $ui-grid-default-spacing;
         }
 
         &-dropdown-filter {

--- a/projects/angular/components/ui-suggest/src/ui-suggest.component.html
+++ b/projects/angular/components/ui-suggest/src/ui-suggest.component.html
@@ -37,6 +37,7 @@
                  (keydown.space)="preventDefault($event)"
                  (focus)="onFocus();"
                  (blur)="onBlur()"
+                 #displayContainer
                  matRipple
                  class="display"
                  role="combobox">
@@ -173,7 +174,7 @@
          (keydown.esc)="preventDefault($event)"
          (keyup.esc)="preventDefault($event);
             close();"
-         (keydown.tab)="close(false)"
+         (keydown.tab)="onOptionsDropdownTabPressed()"
          (keydown.shift.tab)="close()"
          tabindex="-1"
          class="ui-suggest-dropdown-item-list-container">

--- a/projects/angular/components/ui-suggest/src/ui-suggest.component.spec.ts
+++ b/projects/angular/components/ui-suggest/src/ui-suggest.component.spec.ts
@@ -990,6 +990,29 @@ const sharedSpecifications = (
             assert.isOpen();
         });
 
+        it('should focus the display element if Tab key is pressed and the dropdown is open', () => {
+            fixture.detectChanges();
+
+            const display = fixture.debugElement.query(By.css('.display'));
+            display.nativeElement.dispatchEvent(
+                EventGenerator.keyDown(Key.Enter),
+            );
+
+            fixture.detectChanges();
+
+            const itemContainer = fixture.debugElement.query(By.css('.ui-suggest-dropdown-item-list-container'));
+            itemContainer.nativeElement.dispatchEvent(
+                EventGenerator.keyDown(Key.Tab),
+            );
+
+            fixture.detectChanges();
+
+            // We can't test if the next element is focused because jasmine can't simulate the default behavior of the TAB key.
+            // We will test if the implemented logic is working.
+            // https://stackoverflow.com/questions/25032300/jasmine-test-simulate-tab-keydown-and-detect-newly-focused-element
+            expect(document.activeElement).toBe(display.nativeElement);
+        });
+
         it('should close if Tab is pressed', () => {
             fixture.detectChanges();
             const display = fixture.debugElement.query(By.css('.display'));
@@ -2760,7 +2783,7 @@ describe('Component: UiSuggest', () => {
                             [drillDown]="drillDown"
                             [compact]="compact"
                             formControlName="test">
-            </ui-suggest>
+                </ui-suggest>
             </mat-form-field>
         </form>
         `,

--- a/projects/angular/components/ui-suggest/src/ui-suggest.component.ts
+++ b/projects/angular/components/ui-suggest/src/ui-suggest.component.ts
@@ -684,6 +684,7 @@ export class UiSuggestComponent extends UiSuggestMatFormFieldDirective
     suggestContainerWidth = 0;
 
     @ViewChild('suggestContainer') suggestContainer!: ElementRef;
+    @ViewChild('displayContainer') displayContainer?: ElementRef;
 
     @ViewChild(CdkVirtualScrollViewport)
     protected set _virtualScrollerQuery(value: CdkVirtualScrollViewport) {
@@ -1292,6 +1293,13 @@ export class UiSuggestComponent extends UiSuggestMatFormFieldDirective
         return this.value.length > 0
             ? this._getValueSummary()
             : this.defaultValue;
+    }
+
+    onOptionsDropdownTabPressed() {
+        if (this.isOpen && !this.expandInline) {
+            this.displayContainer?.nativeElement.focus();
+        }
+        this.close(false);
     }
 
     private _getDropdownPositionAccordingToDirection() {


### PR DESCRIPTION
**Description**
Now the focus will go to the next element when the user press the TAB key.

Minor change: changed the style for the grid

**JIRA**
[ACTV-63316](https://uipath.atlassian.net/browse/ACTV-63316)
[ACTV-63441](https://uipath.atlassian.net/browse/ACTV-63441)


[ACTV-63316]: https://uipath.atlassian.net/browse/ACTV-63316?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[ACTV-63441]: https://uipath.atlassian.net/browse/ACTV-63441?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ