### PR TITLE
fix(suggest): use debounceTime input after it is set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# v14.8.3 (2023-06-16)
+* **suggest** use debounceTime input after it is set
+
 # v14.8.2 (2023-05-31)
 * **grid** move radio btn in radio group
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "angular-components",
-  "version": "14.8.2",
+  "version": "14.8.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "angular-components",
-      "version": "14.8.2",
+      "version": "14.8.3",
       "license": "MIT",
       "dependencies": {
         "@angular/animations": "14.2.12",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "angular-components",
-  "version": "14.8.2",
+  "version": "14.8.3",
   "author": {
     "name": "UiPath Inc",
     "url": "https://uipath.com"

--- a/projects/angular/components/ui-suggest/src/ui-suggest.component.ts
+++ b/projects/angular/components/ui-suggest/src/ui-suggest.component.ts
@@ -779,7 +779,7 @@ export class UiSuggestComponent extends UiSuggestMatFormFieldDirective
         end: Number.POSITIVE_INFINITY,
     };
 
-    private _inputChange$: Observable<string>;
+    private _inputChange$!: Observable<string>;
     private _drillDown = false;
     private _lazyLoadLastArgument: any[] = ['', 0, 0];
 
@@ -810,34 +810,6 @@ export class UiSuggestComponent extends UiSuggestMatFormFieldDirective
             cd,
             ngControl,
         );
-
-        this._inputChange$ = combineLatest([
-            this.inputControl.valueChanges.pipe(
-                startWith(''),
-                map((v = '') => v.trim()),
-                distinctUntilChanged(),
-                filter(v => v.length >= this.minChars),
-                tap(v => v && this.multiple && this.open()),
-                tap(this._setLoadingState),
-                debounceTime(this.debounceTime),
-                filter(_ => !!this.searchSourceFactory),
-            ),
-            this._disabled$.pipe(filter(v => !v)),
-            this._fetchStrategy$
-                .pipe(
-                    switchMap(strategy => {
-                        switch (strategy) {
-                            case 'onOpen':
-                                return this._isOpen$.pipe(filter(o => !!o));
-                            case 'eager':
-                                return of(strategy);
-                        }
-                    }),
-                ),
-        ]).pipe(
-            map(([value]) => value),
-        );
-
         this._initResizeObserver();
 
         this._height$.subscribe(heightValue => {
@@ -876,6 +848,35 @@ export class UiSuggestComponent extends UiSuggestMatFormFieldDirective
 
         this._initOverlayPositions();
         this.dropdownPosition = [this.direction && this.direction === 'up' ? this.upPosition : this.downPosition];
+
+        this._inputChange$ = combineLatest([
+            this.inputControl.valueChanges.pipe(
+                startWith(''),
+                map((v = '') => v.trim()),
+                distinctUntilChanged(),
+                filter(v => v.length >= this.minChars),
+                tap(v => v && this.multiple && this.open()),
+                tap(this._setLoadingState),
+                debounceTime(this.debounceTime),
+                filter(_ => !!this.searchSourceFactory),
+            ),
+            this._disabled$.pipe(
+                filter(v => !v),
+            ),
+            this._fetchStrategy$
+                .pipe(
+                    switchMap(strategy => {
+                        switch (strategy) {
+                            case 'onOpen':
+                                return this._isOpen$.pipe(filter(o => !!o));
+                            case 'eager':
+                                return of(strategy);
+                        }
+                    }),
+                ),
+        ]).pipe(
+            map(([value]) => value as any),
+        );
 
         merge(
             this._reset$.pipe(

--- a/projects/angular/package.json
+++ b/projects/angular/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@uipath/angular",
-    "version": "14.8.2",
+    "version": "14.8.3",
     "license": "MIT",
     "author": {
         "name": "UiPath Inc",


### PR DESCRIPTION
`this.debounceTime` is used in the constructor, although it is an input, so we need to move the logic that uses it in `ngOnInit`, otherwise its default is always used instead.