### PR TITLE
fix(grid): search filters initial value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# v14.8.5 (2023-07-10)
+* **grid** search filters initial value
+
 # v14.8.4 (2023-06-20)
 * **grid** select by clicking the row
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "angular-components",
-  "version": "14.8.4",
+  "version": "14.8.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "angular-components",
-      "version": "14.8.4",
+      "version": "14.8.5",
       "license": "MIT",
       "dependencies": {
         "@angular/animations": "14.2.12",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "angular-components",
-  "version": "14.8.4",
+  "version": "14.8.5",
   "author": {
     "name": "UiPath Inc",
     "url": "https://uipath.com"

--- a/projects/angular/components/ui-grid/src/filters/ui-grid-search-filter.directive.ts
+++ b/projects/angular/components/ui-grid/src/filters/ui-grid-search-filter.directive.ts
@@ -123,8 +123,16 @@ export class UiGridSearchFilterDirective<T> extends UiGridFilterDirective<T> imp
         this.filterChange.complete();
     }
 
+    private checkAlreadyExisting(value: ISuggestValue, isSelected?: boolean) {
+        if (this.multiple) {
+            return (isSelected && (this.value as ISuggestValue[] ?? []).find(item => item.id === value.id));
+        }
+
+        return false;
+    }
+
     private handleMultiple(value?: ISuggestValue, isSelected?: boolean) {
-        if (!value) {
+        if (!value || this.checkAlreadyExisting(value, isSelected)) {
             return;
         }
 

--- a/projects/angular/components/ui-grid/src/ui-grid.component.spec.ts
+++ b/projects/angular/components/ui-grid/src/ui-grid.component.spec.ts
@@ -38,6 +38,7 @@ import {
     ResizeStrategy,
 } from '@uipath/angular/components/ui-grid';
 import {
+    ISuggestValueData,
     ISuggestValues,
     UiSuggestComponent,
 } from '@uipath/angular/components/ui-suggest';
@@ -1327,7 +1328,7 @@ describe('Component: UiGrid', () => {
                                 [searchable]="true"
                                 title="String Header"
                                 width="50%">
-                    <ui-grid-search-filter [searchSourceFactory]="searchFactory"></ui-grid-search-filter>
+                    <ui-grid-search-filter [searchSourceFactory]="searchFactory" [value]="value" [multiple]="multiple"></ui-grid-search-filter>
                 </ui-grid-column>
             </ui-grid>
         `,
@@ -1342,6 +1343,9 @@ describe('Component: UiGrid', () => {
         dropdownItemList: IDropdownOption[] = [];
         showAllOption?: boolean;
         search?: boolean;
+
+        value?: ISuggestValueData<ITestEntity>[];
+        multiple = false;
 
         searchFactory = (): Observable<ISuggestValues<any>> => of({
             data: this.dropdownItemList
@@ -1372,7 +1376,7 @@ describe('Component: UiGrid', () => {
             fixture = TestBed.createComponent(TestFixtureGridHeaderWithFilterComponent);
             component = fixture.componentInstance;
             grid = component.grid;
-            grid.data = generateListFactory(generateEntity)();
+            component.data = generateListFactory(generateEntity)();
         });
 
         afterEach(() => {
@@ -1614,6 +1618,26 @@ describe('Component: UiGrid', () => {
 
                 expect(searchFilter.items.length).toEqual(0);
             }));
+
+            it('should correctly set the initial value', () => {
+                component.multiple = true;
+                component.value = [{
+                    id: component.data?.[0]?.id ?? '',
+                    text: component.data?.[0]?.myString ?? '',
+                }];
+
+                fixture.detectChanges();
+
+                expect(grid.filterManager.filter$.value).toEqual([{
+                    method: undefined as any,
+                    property: 'myString',
+                    value: [component.data?.[0]?.id ?? ''] as any,
+                    meta: [{
+                        id: component.data?.[0]?.id ?? '',
+                        text: component.data?.[0]?.myString ?? '',
+                    }],
+                }]);
+            });
         });
 
         describe('Event: dropdown filter change', () => {

--- a/projects/angular/package.json
+++ b/projects/angular/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@uipath/angular",
-    "version": "14.8.4",
+    "version": "14.8.5",
     "license": "MIT",
     "author": {
         "name": "UiPath Inc",


### PR DESCRIPTION
In case we pass in a default value for multiple filters, they get duplicated (this breaks the react wrapper that we did).