### PR TITLE
chore: bump version to v14.8.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+# v14.8.6 (2023-07-11)
+
 # v14.8.5 (2023-07-10)
 * **grid** search filters initial value
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "angular-components",
-  "version": "14.8.5",
+  "version": "14.8.6",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "angular-components",
-      "version": "14.8.5",
+      "version": "14.8.6",
       "license": "MIT",
       "dependencies": {
         "@angular/animations": "14.2.12",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "angular-components",
-  "version": "14.8.5",
+  "version": "14.8.6",
   "author": {
     "name": "UiPath Inc",
     "url": "https://uipath.com"

--- a/projects/angular/package.json
+++ b/projects/angular/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@uipath/angular",
-    "version": "14.8.5",
+    "version": "14.8.6",
     "license": "MIT",
     "author": {
         "name": "UiPath Inc",


### PR DESCRIPTION
Some `console.log` leaked in the previous version (I don't understand how, I only built locally with that but published from the pipeline and got timeout when I tried to publish from local).