### PR TITLE
fix(grid): use arrow cursor on column header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# v14.8.7 (2023-07-20)
+* **grid** arrow cursor on grid header text
+
 # v14.8.6 (2023-07-19)
 * **a11y** certain aria roles must contain particular children in grid
 * **deps-dev** bump word-wrap from 1.2.3 to 1.2.4

--- a/projects/angular/components/ui-grid/src/ui-grid.component.html
+++ b/projects/angular/components/ui-grid/src/ui-grid.component.html
@@ -164,7 +164,8 @@
                                [matTooltip]="column.title + (focusedColumnHeader ? ('\n' + column.description) : '')"
                                [matTooltipDisabled]="resizeManager.isResizing"
                                [attr.aria-label]="column.title + (column.description ? ('. ' + column.description) : '') + (column.sortable && intl.sortableMessage ? '. ' + intl.sortableMessage : '')"
-                               matTooltipClass="preserve-whitespace">
+                               matTooltipClass="preserve-whitespace"
+                               class="ui-grid-header-text">
                                 {{ column.title }}
                             </p>
 

--- a/projects/angular/components/ui-grid/src/ui-grid.component.scss
+++ b/projects/angular/components/ui-grid/src/ui-grid.component.scss
@@ -373,6 +373,10 @@ ui-grid {
                 p {
                     @extend %ellipse;
                 }
+
+                .ui-grid-header-text {
+                    cursor: default;
+                }
             }
 
             .ui-grid-cell-content {


### PR DESCRIPTION
Use an arrow cursor instead of text select cursor on headers of columns which are not sortable.

https://uipath.atlassian.net/browse/PLT-29992