### PR TITLE
fix(a11y): certain aria roles must contain particular children in grid

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# v14.8.6 (2023-07-19)
+* **a11y** certain aria roles must contain particular children in grid
+* **deps-dev** bump word-wrap from 1.2.3 to 1.2.4
+
 # v14.8.5 (2023-07-10)
 * **grid** search filters initial value
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "angular-components",
-  "version": "14.8.5",
+  "version": "14.8.6",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "angular-components",
-      "version": "14.8.5",
+      "version": "14.8.6",
       "license": "MIT",
       "dependencies": {
         "@angular/animations": "14.2.12",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "angular-components",
-  "version": "14.8.5",
+  "version": "14.8.6",
   "author": {
     "name": "UiPath Inc",
     "url": "https://uipath.com"

--- a/projects/angular/components/ui-grid/src/ui-grid.component.html
+++ b/projects/angular/components/ui-grid/src/ui-grid.component.html
@@ -474,10 +474,10 @@
     <div cdkMonitorSubtreeFocus
          class="ui-grid-card-wrapper"
          [ngClass]="rowConfig?.ngClassFn(row) ?? ''"
-         [tabIndex]="0"
          [attr.data-row-index]="index"
          (click)="onRowClick($event, row)"
-         (keyup.enter)="onRowClick($event, row)">
+         (keyup.enter)="onRowClick($event, row)"
+         role="row">
         <ng-container *ngIf="cardTemplate?.html; else defaultCardTemplate">
             <ng-container *ngTemplateOutlet="cardTemplate?.html || defaultCardTemplate;context: {
                 data: row,
@@ -492,13 +492,15 @@
 <ng-template #defaultCardTemplate
              let-row="data"
              let-index="index">
-    <div class="ui-grid-card-default">
+    <div
+         class="ui-grid-card-default"
+         role="gridcell"
+         tabindex="0">
         <ng-container *ngFor="let column of renderedColumns$ | async">
             <div [class.ui-grid-primary]="column.directive.primary"
                  [class.ui-grid-secondary]="!column.directive.primary"
                  [attr.data-property]="column.directive.property"
                  [attr.data-identifier]="column.directive.identifier"
-                 [attr.role]="column.role"
                  class="ui-grid-card-default-cell">
                 <div *ngIf="isProjected"
                      [matTooltip]="column.directive.title ?? ''"

--- a/projects/angular/package.json
+++ b/projects/angular/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@uipath/angular",
-    "version": "14.8.5",
+    "version": "14.8.6",
     "license": "MIT",
     "author": {
         "name": "UiPath Inc",

--- a/projects/playground/src/app/pages/grid/component/grid.component.html
+++ b/projects/playground/src/app/pages/grid/component/grid.component.html
@@ -118,7 +118,7 @@
             let-last="last"
             let-index="index"
         >
-            <div class="card">
+            <div class="card" role="gridcell" tabindex="0">
                 <h2>{{data.name}}</h2>
                 <p>parity: <b>{{data.parity}}</b></p>
 


### PR DESCRIPTION
Add role="row" to card wrapper. Remove tabindex="0" from card wrapper. 
The card view template is now responsible for settings role="gridcell" and focus