### PR TITLE
fix(a11y): make columns reset button focusable

### DIFF
--- a/projects/angular/components/ui-grid/src/components/ui-grid-toggle-columns/ui-grid-toggle-columns.component.html
+++ b/projects/angular/components/ui-grid/src/components/ui-grid-toggle-columns/ui-grid-toggle-columns.component.html
@@ -22,20 +22,21 @@
                 <mat-icon class="material-icons-outlined">view_column</mat-icon> {{ toggleTitle }}
             </span>
 
-            <a #resetBtn
-               *ngIf="dirty"
-               [matTooltip]="resetToDefaults ?? ''"
-               (click)="reset()"
-               (keydown.enter)="reset()"
-               (keydown.space)="reset()"
-               (keydown)="resetKeyDown($event)"
-               class="ui-grid-toggle-reset"
-               role="button"
-               color="primary"
-               tabindex="-1"
-               mat-button>
+            <button #resetBtn
+                    *ngIf="dirty"
+                    [matTooltip]="resetToDefaults ?? ''"
+                    (click)="reset()"
+                    (keydown.enter)="reset()"
+                    (keydown.space)="reset()"
+                    (keydown)="resetKeyDown($event)"
+                    mat-button
+                    type="button"
+                    class="ui-grid-toggle-reset"
+                    role="button"
+                    color="primary"
+                    tabindex="-1">
                 {{resetToDefaults}}
-            </a>
+            </button>
 
             <mat-option *ngFor="let o of options"
                         [matTooltip]="o.label"


### PR DESCRIPTION
Makes columns reset button accessible by keyboard.

https://uipath.atlassian.net/browse/PLT-35789