### PR TITLE
🚧 Feat/scrollable grid resize strategy

### DIFF
--- a/projects/angular/components/ui-grid/src/body/ui-grid-column.directive.ts
+++ b/projects/angular/components/ui-grid/src/body/ui-grid-column.directive.ts
@@ -192,6 +192,13 @@ export class UiGridColumnDirective<T> implements OnChanges, OnDestroy {
     minWidth = 30;
 
     /**
+     * The maximum width percentage that the column should have when resizing.
+     *
+     */
+    @Input()
+    maxWidth = 120;
+
+    /**
      * If the searchable dropdown associated to the column should trigger a data fetch when opened.
      *
      */

--- a/projects/angular/components/ui-grid/src/managers/resize/resize-manager.constants.ts
+++ b/projects/angular/components/ui-grid/src/managers/resize/resize-manager.constants.ts
@@ -21,6 +21,10 @@ export function isMinWidth<T>(entry?: IResizeInfo<T>) {
     return !!entry && parseInt(entry.element.style.width!, 10) === entry.column.minWidth;
 }
 
+export function isMaxWidth<T>(entry?: IResizeInfo<T>) {
+    return !!entry && parseInt(entry.element.style.width!, 10) === entry.column.maxWidth;
+}
+
 /**
  * Detects if the resize direction has changed compared to it's previous state.
  *

--- a/projects/angular/components/ui-grid/src/managers/resize/resize-manager.factory.ts
+++ b/projects/angular/components/ui-grid/src/managers/resize/resize-manager.factory.ts
@@ -1,10 +1,9 @@
-import { AggressiveGridResizer } from 'projects/angular/components/ui-grid/src/managers/resize/strategies/aggressive-grid-resizer';
-
 import { IGridDataEntry } from '../../models';
 import { ResizeManager } from './resize-manager';
 import {
     AggresiveNeighbourPushResizer,
     ImmediateNeighbourHaltResizer,
+    ScrollableGridNeighbourPush,
 } from './strategies';
 import {
     ResizableGrid,
@@ -27,7 +26,7 @@ export const ResizeManagerFactory =
                 return new AggresiveNeighbourPushResizer(grid);
             case ResizeStrategy.ImmediateNeighbourHalt:
                 return new ImmediateNeighbourHaltResizer(grid);
-            case ResizeStrategy.AggressiveGridResizer:
-                return new AggressiveGridResizer(grid);
+            case ResizeStrategy.ScrollableGridNeighbourPush:
+                return new ScrollableGridNeighbourPush(grid);
         }
     };

--- a/projects/angular/components/ui-grid/src/managers/resize/resize-manager.factory.ts
+++ b/projects/angular/components/ui-grid/src/managers/resize/resize-manager.factory.ts
@@ -1,3 +1,5 @@
+import { AggressiveGridResizer } from 'projects/angular/components/ui-grid/src/managers/resize/strategies/aggressive-grid-resizer';
+
 import { IGridDataEntry } from '../../models';
 import { ResizeManager } from './resize-manager';
 import {
@@ -25,5 +27,7 @@ export const ResizeManagerFactory =
                 return new AggresiveNeighbourPushResizer(grid);
             case ResizeStrategy.ImmediateNeighbourHalt:
                 return new ImmediateNeighbourHaltResizer(grid);
+            case ResizeStrategy.AggressiveGridResizer:
+                return new AggressiveGridResizer(grid);
         }
     };

--- a/projects/angular/components/ui-grid/src/managers/resize/strategies/aggressive-grid-resizer.ts
+++ b/projects/angular/components/ui-grid/src/managers/resize/strategies/aggressive-grid-resizer.ts
@@ -1,0 +1,74 @@
+import { IGridDataEntry } from '../../../models';
+import { ResizeManager } from '../resize-manager';
+import {
+    clampOffset,
+    isDirectionChanged,
+    isMinWidth,
+} from '../resize-manager.constants';
+import {
+    IResizeEvent,
+    ResizeDirection,
+} from '../types';
+
+/**
+ * @internal
+ * @ignore
+ */
+export class AggressiveGridResizer<T extends IGridDataEntry> extends ResizeManager<T> {
+    protected _stateFilter = (state: IResizeEvent<T>) => {
+        if (isDirectionChanged(state)) {
+            // if the direction has changed while actively resizing
+            // simulate a stop/start to reset the stored offset
+            this._simulateStopFor(state.current.event, state.current.resized, state.previous.neighbour, state.previous.oppositeNeighbour);
+            return false;
+        }
+
+        return true;
+    };
+
+    protected _resizeLeftFilter = (state: IResizeEvent<T>) => {
+        if (state.current.direction !== ResizeDirection.Left) { return true; }
+
+        // if the resize limit is reached simulate a stop
+        if (isMinWidth(state.current.resized)) {
+            this._simulateStopFor(state.current.event, state.current.resized, state.current.oppositeNeighbour);
+            return false;
+        }
+
+        return true;
+    };
+
+    protected _resizeRightFilter = (state: IResizeEvent<T>) => {
+        if (state.current.direction !== ResizeDirection.Right) { return true; }
+
+        if (
+            isMinWidth(state.current.neighbour) ||
+            !state.current.neighbour
+        ) {
+            this._simulateStopFor(state.current.event, state.current.resized, state.current.neighbour);
+            return false;
+        }
+
+        return true;
+    };
+
+    protected _stateUpdate = (state: IResizeEvent<T>) => {
+        if (state.current.direction === ResizeDirection.Left) {
+            const offset = clampOffset(state.current.resized, state.current.offsetPercent);
+            // reduce the current column width
+            // or the left neighbour width
+            this._applyOffsetFor(state.current.resized, offset);
+            // if resize is possible add to the right neighbour's width
+            // in order to preserve the total width
+            this._applyOffsetFor(state.current.oppositeNeighbour, -offset);
+        }
+
+        if (state.current.direction === ResizeDirection.Right) {
+            const offset = -clampOffset(state.current.neighbour, -state.current.offsetPercent);
+            // reduce width of the right neighbour
+            this._applyOffsetFor(state.current.neighbour, -offset);
+            // add the stolen width to the actively resized column
+            this._applyOffsetFor(state.current.resized, offset);
+        }
+    };
+}

--- a/projects/angular/components/ui-grid/src/managers/resize/strategies/index.ts
+++ b/projects/angular/components/ui-grid/src/managers/resize/strategies/index.ts
@@ -1,2 +1,3 @@
 export * from './immediate-neighbour-halt-resizer';
 export * from './aggresive-neighbour-push-resizer';
+export * from './scrollable-grid-neighbour-push-resizer';

--- a/projects/angular/components/ui-grid/src/managers/resize/strategies/scrollable-grid-neighbour-push-resizer.ts
+++ b/projects/angular/components/ui-grid/src/managers/resize/strategies/scrollable-grid-neighbour-push-resizer.ts
@@ -1,0 +1,119 @@
+import { UiGridColumnDirective } from '@uipath/angular/components/ui-grid';
+import { IGridDataEntry } from '../../../models';
+import { ResizeManager } from '../resize-manager';
+import {
+    clampOffset,
+    isDirectionChanged,
+    isMaxWidth,
+    isMinWidth,
+} from '../resize-manager.constants';
+import {
+    IResizeEvent,
+    ResizeDirection,
+} from '../types';
+
+/**
+ * @internal
+ * @ignore
+ */
+export class ScrollableGridNeighbourPush<T extends IGridDataEntry> extends ResizeManager<T> {
+    private _isWidthLimitReached = false;
+
+    setupState(ev: MouseEvent, column: UiGridColumnDirective<T>) {
+        super.setupState(ev, column);
+        this._isWidthLimitReached = false;
+    }
+
+    protected _stateFilter = (state: IResizeEvent<T>) => {
+        if (isDirectionChanged(state)) {
+            // if the direction has changed while actively resizing
+            // simulate a stop/start to reset the stored offset
+            this._simulateStopFor(
+                state.current.event!,
+                state.current.resized,
+                state.previous.neighbour!,
+                state.previous.oppositeNeighbour!,
+            );
+            return false;
+        }
+
+        if (isMaxWidth(state.current.neighbour)) {
+            // if the current pushed column has reached its width limit
+            // simulate a stop/start to reset the stored offset
+            this._simulateStopFor(state.current.event, state.current.resized, state.current.neighbour, state.current.oppositeNeighbour);
+
+            // update the neighbour offset
+            this._neighbourIndexOffset += state.current.direction;
+            return false;
+        }
+
+        return true;
+    };
+
+    protected _resizeLeftFilter = (state: IResizeEvent<T>) => {
+        if (state.current.direction !== ResizeDirection.Left) { return true; }
+
+        // if the current column reached the minimum
+        // and there are no more neighbours left, skip
+        if (
+            isMinWidth(state.current.resized) &&
+            !state.current.neighbour ||
+            isMinWidth(state.current.neighbour)
+        ) { return false; }
+
+        // if the resize limit is reached, then mark it
+        // and simulate a stop
+        if (
+            !this._isWidthLimitReached &&
+            isMinWidth(state.current.resized)
+        ) {
+            this._simulateStopFor(state.current.event!, state.current.resized, state.current.oppositeNeighbour!);
+            this._isWidthLimitReached = true;
+            return false;
+        }
+
+        return true;
+    };
+
+    protected _resizeRightFilter = (state: IResizeEvent<T>) => {
+        if (state.current.direction !== ResizeDirection.Right) { return true; }
+
+        // reset width limit flag
+        this._isWidthLimitReached = false;
+
+        if (
+            isMinWidth(state.current.neighbour) ||
+            !state.current.neighbour
+        ) {
+            this._simulateStopFor(state.current.event!, state.current.resized, state.current.neighbour);
+            return false;
+        }
+
+        return true;
+    };
+
+    protected _stateUpdate = (state: IResizeEvent<T>) => {
+        if (state.current.direction === ResizeDirection.Left) {
+            // determine reduced column
+            const active = isMinWidth(state.current.resized) ?
+                state.current.neighbour! :
+                state.current.resized!;
+
+            const offset = clampOffset(active, state.current.offsetPercent);
+            // reduce the current column width
+            // or the left neighbour width
+            this._applyOffsetFor(active, offset);
+            // if resize is possible add to the right neighbours width
+            // in order to preserve the total width
+            this._applyOffsetFor(state.current.oppositeNeighbour, -offset);
+        }
+
+        if (state.current.direction === ResizeDirection.Right) {
+            const offset = -clampOffset(state.current.neighbour, -state.current.offsetPercent);
+            // reduce width of the right neighbour
+            this._applyOffsetFor(state.current.neighbour, -offset);
+            // add the stolen width to the actively resized column
+            this._applyOffsetFor(state.current.resized, offset);
+        }
+    };
+}

--- a/projects/angular/components/ui-grid/src/managers/resize/types/resizeInfo.ts
+++ b/projects/angular/components/ui-grid/src/managers/resize/types/resizeInfo.ts
@@ -10,4 +10,5 @@ export interface IResizeInfo<T> {
     cells: HTMLDivElement[];
     index: number;
     dragInitX?: number;
+    firstDragInitX?: number;
 }

--- a/projects/angular/components/ui-grid/src/managers/resize/types/resizeState.ts
+++ b/projects/angular/components/ui-grid/src/managers/resize/types/resizeState.ts
@@ -9,7 +9,9 @@ export interface IResizeState<T> {
     resized: IResizeInfo<T>;
     neighbour?: IResizeInfo<T>;
     oppositeNeighbour?: IResizeInfo<T>;
+    globalOffsetPx: number;
     offsetPx: number;
+    globalOffsetPercent: number;
     offsetPercent: number;
     direction: ResizeDirection;
     event?: MouseEvent;

--- a/projects/angular/components/ui-grid/src/managers/resize/types/resizeStrategy.ts
+++ b/projects/angular/components/ui-grid/src/managers/resize/types/resizeStrategy.ts
@@ -6,5 +6,5 @@ export enum ResizeStrategy {
     AggresiveNeighbourPush = 0,
     PassiveNeighbourPush,
     ImmediateNeighbourHalt,
-    AggressiveGridResizer
+    ScrollableGridNeighbourPush,
 }

--- a/projects/angular/components/ui-grid/src/managers/resize/types/resizeStrategy.ts
+++ b/projects/angular/components/ui-grid/src/managers/resize/types/resizeStrategy.ts
@@ -6,4 +6,5 @@ export enum ResizeStrategy {
     AggresiveNeighbourPush = 0,
     PassiveNeighbourPush,
     ImmediateNeighbourHalt,
+    AggressiveGridResizer
 }

--- a/projects/angular/components/ui-grid/src/ui-grid.component.html
+++ b/projects/angular/components/ui-grid/src/ui-grid.component.html
@@ -115,9 +115,11 @@
              role="grid">
             <div class="ui-grid-header">
                 <div *ngIf="showHeaderRow"
+                     [style.width]="width"
                      class="ui-grid-header-row"
                      role="row">
                     <div *ngIf="selectable && !singleSelectable"
+                         [class.test1001]="freezeColumns > 0"
                          class="ui-grid-header-cell ui-grid-checkbox-cell ui-grid-feature-cell"
                          role="columnheader">
                         <mat-checkbox #selectAvailableRowsCheckbox
@@ -143,10 +145,12 @@
                         <div [class.ui-grid-header-cell-sortable]="column.sortable"
                              [class.ui-grid-resizeable]="column.resizeable"
                              [class.ui-grid-state-resizing]="column === resizeManager.current?.column"
+                             [class.test1001]="columnIndex + 1 < freezeColumns"
                              [attr.aria-sort]="column.ariaSort"
                              [attr.data-property]="column.property"
                              [attr.data-identifier]="column.identifier"
                              [style.width.%]="column.width"
+                             [style.left.px]="columnIndex + 1 < freezeColumns ? columnLeft[columnIndex + 1] : ''"
                              (cdkFocusChange)="triggerColumnHeaderTooltip($event, columnTooltip)"
                              (focusout)="hideColumnHeaderTooltip(columnTooltip)"
                              (keyup.enter)="sortManager.changeSort(column)"
@@ -195,6 +199,8 @@
 
                         <div *ngIf="!isProjected && column.resizeable && !last && !useCardView"
                              [class.ui-grid-state-resizing]="column === resizeManager.current?.column"
+                             [class.test1001]="columnIndex + 1 < freezeColumns"
+                             [style.left.px]="columnIndex + 1 < freezeColumns ? gridResizeHandleLeft[columnIndex + 1] : ''"
                              (mousedown)="resizeManager.startResize($event, column, columnIndex)"
                              class="ui-grid-resize-handle">
                         </div>
@@ -330,6 +336,7 @@
          [ngClass]="rowConfig?.ngClassFn(row) ?? ''"
          [tabIndex]="0"
          [attr.data-row-index]="index"
+         [style.width]="width"
          (click)="onRowClick($event, row)"
          (keyup.enter)="onRowClick($event, row)"
          role="row">
@@ -372,39 +379,45 @@
             </div>
         </div>
 
-        <div *ngIf="!isProjected && (selectable || singleSelectable)"
-             class="ui-grid-cell ui-grid-checkbox-cell ui-grid-feature-cell"
-             role="gridcell">
-            <ng-container *ngLet="disableSelectionByEntry(row) as disabledReason">
-                <mat-radio-group *ngIf="singleSelectable; else multiSelectable">
-                    <mat-radio-button [value]="row.id"
+        <ng-container *ngIf="freezeColumns > 0">
+            <div *ngIf="!isProjected && (selectable || singleSelectable)"
+                 [class.test1001]="freezeColumns > 0"
+                 class="ui-grid-cell ui-grid-checkbox-cell ui-grid-feature-cell"
+                 role="gridcell">
+                <ng-container *ngLet="disableSelectionByEntry(row) as disabledReason">
+                    <mat-radio-group *ngIf="singleSelectable; else multiSelectable">
+                        <mat-radio-button [value]="row.id"
+                                          [checked]="selectionManager.isSelected(row)"
+                                          [disabled]="disabledReason"
+                                          [matTooltip]="disabledReason || checkboxTooltip(row)"
+                                          [aria-label]="disabledReason || checkboxTooltip(row)"
+                                          (change)="rowSelected(row)"></mat-radio-button>
+                    </mat-radio-group>
+                    <ng-template #multiSelectable>
+                        <mat-checkbox (change)="handleSelection(index, row)"
                                       [checked]="selectionManager.isSelected(row)"
-                                      [disabled]="disabledReason"
+                                      [indeterminate]="selectionManager.isIndeterminate(row)"
                                       [matTooltip]="disabledReason || checkboxTooltip(row)"
                                       [aria-label]="disabledReason || checkboxTooltip(row)"
-                                      (change)="rowSelected(row)"></mat-radio-button>
-                </mat-radio-group>
-                <ng-template #multiSelectable>
-                    <mat-checkbox (change)="handleSelection(index, row)"
-                                  [checked]="selectionManager.isSelected(row)"
-                                  [indeterminate]="selectionManager.isIndeterminate(row)"
-                                  [matTooltip]="disabledReason || checkboxTooltip(row)"
-                                  [aria-label]="disabledReason || checkboxTooltip(row)"
-                                  [disabled]="disabledReason"
-                                  tabindex="0">
-                    </mat-checkbox>
-                </ng-template>
-            </ng-container>
-        </div>
+                                      [disabled]="disabledReason"
+                                      tabindex="0">
+                        </mat-checkbox>
+                    </ng-template>
+                </ng-container>
+            </div>
+        </ng-container>
 
-        <ng-container *ngFor="let column of renderedColumns$ | async; let lastColumn = last">
+        <ng-container
+                      *ngFor="let column of renderedColumns$ | async; let lastColumn = last; let columnIndex = index">
             <div [class.ui-grid-primary]="column.directive.primary"
                  [class.ui-grid-secondary]="!column.directive.primary"
                  [class.ui-grid-state-resizing]="column.directive === resizeManager.current?.column"
                  [attr.data-property]="column.directive.property"
                  [attr.data-identifier]="column.directive.identifier"
                  [style.width.%]="column.directive.width"
+                 [style.left.px]="columnIndex + 1 < freezeColumns ? columnLeft[columnIndex + 1] : ''"
                  [attr.role]="column.role"
+                 [class.test1001]="freezeColumns > 0 && columnIndex + 1 < freezeColumns"
                  class="ui-grid-cell">
                 <div *ngIf="isProjected"
                      [matTooltip]="column.directive.title ?? ''"
@@ -413,17 +426,17 @@
 
                 <div class="ui-grid-cell-content">
                     <ng-container *ngTemplateOutlet="column.directive.html || textCellTemplate; context: {
-                                    data: row,
-                                    index: index,
-                                    property: column.directive.property
-                                }">
+                          data: row,
+                          index: index,
+                          property: column.directive.property
+                      }">
                     </ng-container>
                 </div>
-
-
             </div>
             <div *ngIf="!isProjected && column.directive.resizeable && !lastColumn && !useCardView"
                  [class.ui-grid-state-resizing]="column.directive === resizeManager.current?.column"
+                 [class.test1001]="freezeColumns > 0 && columnIndex + 1 < freezeColumns"
+                 [style.left.px]="columnIndex + 1 < freezeColumns ? cellResizingBorderLeft[columnIndex + 1] : ''"
                  class="ui-grid-cell-resizing-border"></div>
         </ng-container>
 

--- a/projects/angular/components/ui-grid/src/ui-grid.component.html
+++ b/projects/angular/components/ui-grid/src/ui-grid.component.html
@@ -379,7 +379,7 @@
             </div>
         </div>
 
-        <ng-container *ngIf="freezeColumns > 0">
+        <ng-container *ngIf="(freezeColumns && freezeColumns > 0) || !freezeColumns">
             <div *ngIf="!isProjected && (selectable || singleSelectable)"
                  [class.test1001]="freezeColumns > 0"
                  class="ui-grid-cell ui-grid-checkbox-cell ui-grid-feature-cell"

--- a/projects/angular/components/ui-grid/src/ui-grid.component.scss
+++ b/projects/angular/components/ui-grid/src/ui-grid.component.scss
@@ -25,6 +25,15 @@ ui-grid {
     position: relative;
     display: block;
 
+
+    .ui-grid-cell,
+    .ui-grid-header-cell,
+    .ui-grid-cell-resizing-border,
+    .ui-grid-resize-handle {
+        background-color: white !important;
+
+    }
+
     &.ui-grid-mode-multi-select {
         .ui-grid-table {
             cdk-virtual-scroll-viewport.ui-grid-viewport {
@@ -136,6 +145,7 @@ ui-grid {
     }
 
     .ui-grid {
+
         &-primary,
         &-header-cell {
             font-weight: 500;
@@ -228,6 +238,7 @@ ui-grid {
             }
 
             .ui-grid-header {
+
                 &-row,
                 &-cell {
                     height: $ui-grid-header-alternate-row-height;
@@ -384,7 +395,7 @@ ui-grid {
             .ui-grid-cell-content {
                 @extend %ellipse;
 
-                > * {
+                >* {
                     @extend %ellipse;
                 }
             }
@@ -502,7 +513,7 @@ ui-grid {
                     padding: 0;
                     overflow: visible;
 
-                    > div {
+                    >div {
                         display: inline-flex;
                         justify-content: flex-end;
                         align-items: center;
@@ -524,6 +535,7 @@ ui-grid {
 
                     //sorted asc
                     &-asc {
+
                         // desc path
                         .path-desc {
                             opacity: 0;
@@ -531,6 +543,7 @@ ui-grid {
                     }
 
                     &-desc {
+
                         //sorted desc
                         .path-asc {
                             // asc path
@@ -589,6 +602,7 @@ ui-grid {
     left: 0;
     z-index: 1;
 }
+
 .ui-grid-table-container {
     overflow: auto;
 }

--- a/projects/angular/components/ui-grid/src/ui-grid.component.scss
+++ b/projects/angular/components/ui-grid/src/ui-grid.component.scss
@@ -136,8 +136,6 @@ ui-grid {
     }
 
     .ui-grid {
-
-
         &-primary,
         &-header-cell {
             font-weight: 500;
@@ -229,9 +227,7 @@ ui-grid {
                 }
             }
 
-
             .ui-grid-header {
-
                 &-row,
                 &-cell {
                     height: $ui-grid-header-alternate-row-height;
@@ -269,7 +265,6 @@ ui-grid {
                     }
                 }
             }
-
         }
 
         &-table-container {
@@ -331,13 +326,12 @@ ui-grid {
 
         &-resize-handle {
             flex: 0 0 $ui-header-resize-handle-width;
-            margin-left: - $ui-cell-resizing-border-width;
+            margin-left: -$ui-cell-resizing-border-width;
             position: relative;
             height: 100%;
             display: flex;
             cursor: col-resize;
         }
-
 
         &-dropdown-filter {
             &-button {
@@ -390,7 +384,7 @@ ui-grid {
             .ui-grid-cell-content {
                 @extend %ellipse;
 
-                >* {
+                > * {
                     @extend %ellipse;
                 }
             }
@@ -508,7 +502,7 @@ ui-grid {
                     padding: 0;
                     overflow: visible;
 
-                    >div {
+                    > div {
                         display: inline-flex;
                         justify-content: flex-end;
                         align-items: center;
@@ -530,7 +524,6 @@ ui-grid {
 
                     //sorted asc
                     &-asc {
-
                         // desc path
                         .path-desc {
                             opacity: 0;
@@ -538,7 +531,6 @@ ui-grid {
                     }
 
                     &-desc {
-
                         //sorted desc
                         .path-asc {
                             // asc path
@@ -589,4 +581,14 @@ ui-grid {
             }
         }
     }
+}
+
+.test1001 {
+    position: sticky !important;
+    // background: white !important;
+    left: 0;
+    z-index: 1;
+}
+.ui-grid-table-container {
+    overflow: auto;
 }

--- a/projects/angular/components/ui-grid/src/ui-grid.component.ts
+++ b/projects/angular/components/ui-grid/src/ui-grid.component.ts
@@ -878,6 +878,9 @@ export class UiGridComponent<T extends IGridDataEntry>
     }
 
     // eslint-disable-next-line @typescript-eslint/member-ordering
+    readonly ResizeStrategy = ResizeStrategy;
+
+    // eslint-disable-next-line @typescript-eslint/member-ordering
     columnLeft: number[] = [];
     // eslint-disable-next-line @typescript-eslint/member-ordering
     gridResizeHandleLeft: number[] = [];
@@ -910,50 +913,54 @@ export class UiGridComponent<T extends IGridDataEntry>
     previousColumnLeft: number[] = [];
 
     updateOffsetsLeft(resizeEvent: IResizeEvent<T>) {
-        if (this.freezeColumns <= 1) {
-            return;
-        }
-
-        const currentColumn = resizeEvent?.current.resized.column;
-        // TBD: the first checkbox column is not in the column directives list, so we need to add 1 here
-        const columnIndex = this._getIndexOfColumn(currentColumn) + 1;
-
-        //       x
-        // [][][]
-        if (columnIndex >= this.freezeColumns) {
-            return;
-        }
-
-        //    x
-        // [][][]
-
-        const firstRow = this._ref.nativeElement.querySelector('.ui-grid-header-row') as HTMLDivElement;
-        const firstRowCells = firstRow!.querySelectorAll('.ui-grid-header-cell');
-
-        let totalWidth = 0;
-
-        for (let i = 0; i <= columnIndex + 1; i++) {
-            if (i >= columnIndex) {
-                // the columns left and right of the resizing border
-                console.log(`Setting left ${totalWidth} for column ${i}`);
-                this.columnLeft[i] = totalWidth;
-                // TBD: this is not necessary for columnIndex == this.freezeColumns - 1
+        setTimeout(() => {
+            if (this.freezeColumns <= 1) {
+                return;
             }
 
-            totalWidth += firstRowCells[i].getBoundingClientRect().width;
+            const currentColumn = resizeEvent?.current.resized.column;
+            // TBD: the first checkbox column is not in the column directives list, so we need to add 1 here
+            const columnIndex = this._getIndexOfColumn(currentColumn) + 1;
 
-            if (i >= columnIndex) {
-                this.gridResizeHandleLeft[i] = totalWidth - 3;
-                this.cellResizingBorderLeft[i] = totalWidth;
+            //       x
+            // [][][]
+            if (columnIndex >= this.freezeColumns) {
+                return;
             }
 
-            if (i !== 0) {
-                // the first column doesn't have a resizing border
-                totalWidth += 3; // resizing border
-            }
-        }
+            //    x
+            // [][][]
 
-        this._cd.detectChanges();
+            const firstRow = this._ref.nativeElement.querySelector('.ui-grid-header-row') as HTMLDivElement;
+            const firstRowCells = firstRow!.querySelectorAll('.ui-grid-header-cell');
+
+            // todo: get width of resizing border from DOM (do not hardcode it)
+
+            let totalWidth = 0;
+
+            for (let i = 0; i <= columnIndex + 1; i++) {
+                // if (i >= columnIndex) {
+                    // the columns left and right of the resizing border
+                    // console.log(`Setting left ${totalWidth} for column ${i}`);
+                    this.columnLeft[i] = totalWidth;
+                    // TBD: this is not necessary for columnIndex == this.freezeColumns - 1
+                // }
+
+                totalWidth += firstRowCells[i].getBoundingClientRect().width;
+
+                // if (i >= columnIndex) {
+                    this.gridResizeHandleLeft[i] = totalWidth - 3;
+                    this.cellResizingBorderLeft[i] = totalWidth;
+                // }
+
+                if (i !== 0) {
+                    // the first column doesn't have a resizing border
+                    totalWidth += 3; // resizing border
+                }
+            }
+
+            this._cd.detectChanges();
+        }, 0);
     }
 
     onResizeEnd() {

--- a/projects/playground/src/app/pages/grid/component/grid.component.html
+++ b/projects/playground/src/app/pages/grid/component/grid.component.html
@@ -58,6 +58,7 @@
          [showHeaderRow]="inputs.showHeaderRow"
          [expandedEntries]="editedEntity"
          [useCardView]="inputs.useCardView"
+         [resizeStrategy]="header.resizeStrategy"
          [expandMode]="'preserve'"
          [customFilterValue]="inputs.customFilter ? [{property: 'parity', method: 'eq', value: 'odd'}] : []"
          [freezeColumns]="4"

--- a/projects/playground/src/app/pages/grid/component/grid.component.html
+++ b/projects/playground/src/app/pages/grid/component/grid.component.html
@@ -1,4 +1,48 @@
 <ui-grid [data]="data$ | async"
+         [resizeStrategy]="aggressiveGridStrategy"
+         [selectable]="true">
+
+    <ui-grid-column [property]="'id'"
+                    [sortable]="true"
+                    title="Id"
+                    width="10%">
+        <ui-grid-dropdown-filter [visible]="header.showFilter"
+                                 [items]="[{ value: 'even', label: 'Even' }, {value: 'odd', label: 'Odd'}]">
+        </ui-grid-dropdown-filter>
+    </ui-grid-column>
+    <ui-grid-column [property]="'name'"
+                    [searchable]="true"
+                    method="eq"
+                    title="Name 1"
+                    width="20%">
+        <ui-grid-search-filter [visible]="header.showFilter"
+                               [searchSourceFactory]="searchSourceFactory"
+                               [multiple]="true">
+        </ui-grid-search-filter>
+    </ui-grid-column>
+    <ui-grid-column [property]="'name'"
+                    [searchable]="true"
+                    method="eq"
+                    title="Name 2"
+                    width="20%">
+    </ui-grid-column>
+    <ui-grid-column [property]="'name'"
+                    [searchable]="true"
+                    method="eq"
+                    title="Name 3"
+                    width="20%">
+    </ui-grid-column>
+    <ui-grid-column [property]="'parity'"
+                    title="Parity"
+                    width="50%">
+        <ui-grid-dropdown-filter [visible]="header.showFilter"
+                                 [items]="[{ value: 'even', label: 'Even' }, {value: 'odd', label: 'Odd'}]">
+        </ui-grid-dropdown-filter>
+    </ui-grid-column>
+</ui-grid>
+
+
+<ui-grid [data]="data$ | async"
          [collapsibleFilters]="inputs.collapsibleFilters ?? false"
          [collapseFiltersCount]="inputs.collapseFiltersCount"
          [isProjected]="inputs.isProjected"
@@ -17,6 +61,7 @@
          [expandMode]="'preserve'"
          [customFilterValue]="inputs.customFilter ? [{property: 'parity', method: 'eq', value: 'odd'}] : []"
          [freezeColumns]="4"
+         [resizeStrategy]="aggressiveGridStrategy"
          width="1600px">
 
     <ui-grid-header [search]="header.searchable">

--- a/projects/playground/src/app/pages/grid/component/grid.component.html
+++ b/projects/playground/src/app/pages/grid/component/grid.component.html
@@ -15,7 +15,9 @@
          [expandedEntries]="editedEntity"
          [useCardView]="inputs.useCardView"
          [expandMode]="'preserve'"
-         [customFilterValue]="inputs.customFilter ? [{property: 'parity', method: 'eq', value: 'odd'}] : []">
+         [customFilterValue]="inputs.customFilter ? [{property: 'parity', method: 'eq', value: 'odd'}] : []"
+         [freezeColumns]="4"
+         width="1600px">
 
     <ui-grid-header [search]="header.searchable">
         <ui-header-button *ngFor="let button of generateButtons(header.main)"
@@ -52,7 +54,7 @@
     <ui-grid-column [property]="'id'"
                     [sortable]="true"
                     title="Id"
-                    width="33%">
+                    width="10%">
         <ui-grid-dropdown-filter [visible]="header.showFilter"
                                  [items]="[{ value: 'even', label: 'Even' }, {value: 'odd', label: 'Odd'}]">
         </ui-grid-dropdown-filter>
@@ -60,16 +62,28 @@
     <ui-grid-column [property]="'name'"
                     [searchable]="true"
                     method="eq"
-                    title="Name"
-                    width="34%">
+                    title="Name 1"
+                    width="20%">
         <ui-grid-search-filter [visible]="header.showFilter"
                                [searchSourceFactory]="searchSourceFactory"
                                [multiple]="true">
         </ui-grid-search-filter>
     </ui-grid-column>
+    <ui-grid-column [property]="'name'"
+                    [searchable]="true"
+                    method="eq"
+                    title="Name 2"
+                    width="20%">
+    </ui-grid-column>
+    <ui-grid-column [property]="'name'"
+                    [searchable]="true"
+                    method="eq"
+                    title="Name 3"
+                    width="20%">
+    </ui-grid-column>
     <ui-grid-column [property]="'parity'"
                     title="Parity"
-                    width="33%">
+                    width="50%">
         <ui-grid-dropdown-filter [visible]="header.showFilter"
                                  [items]="[{ value: 'even', label: 'Even' }, {value: 'odd', label: 'Odd'}]">
         </ui-grid-dropdown-filter>

--- a/projects/playground/src/app/pages/grid/component/grid.component.ts
+++ b/projects/playground/src/app/pages/grid/component/grid.component.ts
@@ -7,13 +7,17 @@ import {
 import { MockData } from 'projects/playground/src/app/pages/grid/grid.page';
 import {
     BehaviorSubject,
-    combineLatest, Observable, of,
+    combineLatest,
+    Observable,
+    of,
     Subject,
 } from 'rxjs';
 import {
     delay,
-    startWith, switchMap,
-    takeUntil, tap,
+    startWith,
+    switchMap,
+    takeUntil,
+    tap,
 } from 'rxjs/operators';
 
 import {
@@ -29,6 +33,7 @@ import {
 import {
     IFilterModel,
     PageChangeEvent,
+    ResizeStrategy,
     UiGridComponent,
 } from '@uipath/angular/components/ui-grid';
 import { ISuggestValues } from '@uipath/angular/components/ui-suggest';
@@ -66,6 +71,9 @@ export class GridComponent implements OnInit, OnDestroy, AfterViewInit {
 
     editedEntity?: any;
     editedIndex?: number;
+
+    aggressiveNeighbourPushStrategy = ResizeStrategy.AggresiveNeighbourPush;
+    aggressiveGridStrategy = ResizeStrategy.AggressiveGridResizer;
 
     @ViewChild(UiGridComponent)
     private _grid!: UiGridComponent<MockData>;

--- a/projects/playground/src/app/pages/grid/grid.models.ts
+++ b/projects/playground/src/app/pages/grid/grid.models.ts
@@ -1,3 +1,5 @@
+import { ResizeStrategy } from 'dist/angular/components/ui-grid';
+
 export interface IFooter {
     total: number;
     pageSize: number;
@@ -12,6 +14,7 @@ export interface IHeader {
     main: number;
     inline: number;
     action: number;
+    resizeStrategy: ResizeStrategy;
 }
 
 export interface IInputs {

--- a/projects/playground/src/app/pages/grid/grid.page.html
+++ b/projects/playground/src/app/pages/grid/grid.page.html
@@ -42,6 +42,26 @@
                             Header search
                         </mat-checkbox>
 
+                        <mat-form-field>
+                            <mat-select formControlName="resizeStrategy">
+                                <mat-option [value]="ResizeStrategy.AggresiveNeighbourPush">
+                                    AggresiveNeighbourPush
+                                </mat-option>
+
+                                <mat-option [value]="ResizeStrategy.PassiveNeighbourPush">
+                                    PassiveNeighbourPush
+                                </mat-option>
+
+                                <mat-option [value]="ResizeStrategy.ImmediateNeighbourHalt">
+                                    ImmediateNeighbourHalt
+                                </mat-option>
+
+                                <mat-option [value]="ResizeStrategy.ScrollableGridNeighbourPush">
+                                    ScrollableGridNeighbourPush
+                                </mat-option>
+                            </mat-select>
+                        </mat-form-field>
+
                         <mat-checkbox class="header-search-checkbox"
                                       formControlName="showFilter">
                             Show Filter

--- a/projects/playground/src/app/pages/grid/grid.page.module.ts
+++ b/projects/playground/src/app/pages/grid/grid.page.module.ts
@@ -12,7 +12,9 @@ import { MatCardModule } from '@angular/material/card';
 import { MatCheckboxModule } from '@angular/material/checkbox';
 import { MatIconModule } from '@angular/material/icon';
 import { MatInputModule } from '@angular/material/input';
-import { MAT_SELECT_CONFIG } from '@angular/material/select';
+import {
+    MatSelectModule, MAT_SELECT_CONFIG,
+} from '@angular/material/select';
 import { BrowserModule } from '@angular/platform-browser';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import {
@@ -39,6 +41,7 @@ import { GridPageComponent } from './grid.page';
         MatButtonModule,
         MatIconModule,
         MatInputModule,
+        MatSelectModule,
     ],
     providers: [
         {

--- a/projects/playground/src/app/pages/grid/grid.page.ts
+++ b/projects/playground/src/app/pages/grid/grid.page.ts
@@ -28,6 +28,7 @@ import {
     Validators,
 } from '@angular/forms';
 import { PageEvent } from '@angular/material/paginator';
+import { ResizeStrategy } from '@uipath/angular/components/ui-grid';
 
 export interface MockData {
     id: number;
@@ -47,6 +48,8 @@ export class GridPageComponent implements AfterViewInit, OnDestroy {
     lastPageChange?: PageEvent;
     generatedGrid = false;
     visibilityColumnsOpened = false;
+
+    readonly ResizeStrategy = ResizeStrategy;
 
     inputKeys = [
         'useLegacyDesign',
@@ -131,6 +134,7 @@ export class GridPageComponent implements AfterViewInit, OnDestroy {
             header: this._fb.group({
                 searchable: [true],
                 showFilter: [true],
+                resizeStrategy: [ResizeStrategy.ImmediateNeighbourHalt],
                 main: [0, [Validators.min(0), Validators.max(5)]],
                 inline: [0, [Validators.min(0), Validators.max(5)]],
                 action: [0, [Validators.min(0), Validators.max(5)]],


### PR DESCRIPTION
Depends on: https://github.com/UiPath/angular-components/pull/388

Todos: 
- [ ] implement excel style resize strategy 
   - [ ] on downsize reduce cell's size, push right neighbours to their left reducing grid size
   - [ ] on upsizing push right neighbours to the right of the grid
- [ ] enforce columns can take up to a maximum of 500px (other magic number) per column.