### PR TITLE
fix(suggest): input clear for lazy loaded ui-suggest with multiple selection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# v15.0.2-rc.2 (2023-09-29)
+* **suggest** input clear on multiple selection
+* **suggest** reduce height when no results found
+* **grid** remove tooltip on selected radio btn
+
 # v15.0.2-rc.1 (2023-08-22)
 * **grid** display action buttons on one row
 * **grid** styles specificity for empty grid

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "angular-components",
-  "version": "15.0.2-rc.1",
+  "version": "15.0.2-rc.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "angular-components",
-      "version": "15.0.2-rc.1",
+      "version": "15.0.2-rc.2",
       "license": "MIT",
       "dependencies": {
         "@angular/animations": "15.2.9",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "angular-components",
-  "version": "15.0.2-rc.1",
+  "version": "15.0.2-rc.2",
   "author": {
     "name": "UiPath Inc",
     "url": "https://uipath.com"

--- a/projects/angular/components/ui-suggest/src/ui-suggest.component.ts
+++ b/projects/angular/components/ui-suggest/src/ui-suggest.component.ts
@@ -1221,7 +1221,9 @@ export class UiSuggestComponent extends UiSuggestMatFormFieldDirective
             if (!this.multiple) {
                 this._clearSelection();
             } else if (!this.compact) {
-                this.inputControl.setValue('');
+                if (this.inputControl.value) {
+                    this.inputControl.setValue('');
+                }
                 this._focusChipInput();
             }
             this._pushEntry(value);

--- a/projects/angular/package.json
+++ b/projects/angular/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@uipath/angular",
-    "version": "15.0.2-rc.1",
+    "version": "15.0.2-rc.2",
     "license": "MIT",
     "author": {
         "name": "UiPath Inc",


### PR DESCRIPTION
If the user selects previous entries while list is loading, the list would fail to load the resources.

