### PR TITLE
fix: focus suggest chips input after selection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# v15.0.2-rc.6 (2023-10-12)
+* **fix** focus chip input after selection
+
 # v15.0.2-rc.5 (2023-10-03)
 * **suggest** add role for aria attrs in multiple selection scenario
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "angular-components",
-  "version": "15.0.2-rc.5",
+  "version": "15.0.2-rc.6",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "angular-components",
-      "version": "15.0.2-rc.5",
+      "version": "15.0.2-rc.6",
       "license": "MIT",
       "dependencies": {
         "@angular/animations": "15.2.9",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "angular-components",
-  "version": "15.0.2-rc.5",
+  "version": "15.0.2-rc.6",
   "author": {
     "name": "UiPath Inc",
     "url": "https://uipath.com"

--- a/projects/angular/components/ui-suggest/src/ui-suggest.component.ts
+++ b/projects/angular/components/ui-suggest/src/ui-suggest.component.ts
@@ -84,7 +84,7 @@ import {
 
 export const DEFAULT_SUGGEST_DEBOUNCE_TIME = 300;
 export const DEFAULT_SUGGEST_DRILLDOWN_CHARACTER = ':';
-export const MAT_CHIP_INPUT_SELECTOR = '.mat-chip-list input';
+export const MAT_CHIP_INPUT_SELECTOR = '.mat-mdc-chip-grid input';
 
 /**
  * A form compatible `dropdown` packing `lazy-loading` and `virtual-scroll`.

--- a/projects/angular/components/ui-suggest/src/ui-suggest.mat-form-field.ts
+++ b/projects/angular/components/ui-suggest/src/ui-suggest.mat-form-field.ts
@@ -111,7 +111,7 @@ export abstract class UiSuggestMatFormFieldDirective implements
     shouldHideTitle = false;
 
     /**
-     * Sets aria-label on input or mat-chip-list element.
+     * Sets aria-label on input or mat-chip-grid element.
      *
      */
     @Input('aria-label')

--- a/projects/angular/package.json
+++ b/projects/angular/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@uipath/angular",
-    "version": "15.0.2-rc.5",
+    "version": "15.0.2-rc.6",
     "license": "MIT",
     "author": {
         "name": "UiPath Inc",


### PR DESCRIPTION
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 63c179a</samp>

This pull request updates the project and package version to 15.0.2-rc.6 and fixes the focus logic for the `ui-suggest` component by using the correct selector for the `mat-chip-grid` element. It also updates the `CHANGELOG.md` file and a comment to reflect these changes.