### PR TITLE
fix: clear & focus suggest input on deselect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# v15.0.2-rc.7 (2023-10-17)
+* **fix** clear and focus suggest input on deselection
+* **file-picker** create component
+
 # v15.0.2-rc.6 (2023-10-12)
 * **fix** focus chip input after selection
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "angular-components",
-  "version": "15.0.2-rc.6",
+  "version": "15.0.2-rc.7",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "angular-components",
-      "version": "15.0.2-rc.6",
+      "version": "15.0.2-rc.7",
       "license": "MIT",
       "dependencies": {
         "@angular/animations": "15.2.9",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "angular-components",
-  "version": "15.0.2-rc.6",
+  "version": "15.0.2-rc.7",
   "author": {
     "name": "UiPath Inc",
     "url": "https://uipath.com"

--- a/projects/angular/components/ui-suggest/src/ui-suggest.component.ts
+++ b/projects/angular/components/ui-suggest/src/ui-suggest.component.ts
@@ -1220,15 +1220,17 @@ export class UiSuggestComponent extends UiSuggestMatFormFieldDirective
         if (!isItemSelected && value) {
             if (!this.multiple) {
                 this._clearSelection();
-            } else if (!this.compact) {
-                if (this.inputControl.value) {
-                    this.inputControl.setValue('');
-                }
-                this._focusChipInput();
             }
             this._pushEntry(value);
 
             this._announceSelectStatus(value.text, true);
+        }
+
+        if (value && this.multiple && !this.compact) {
+            if (this.inputControl.value) {
+                this.inputControl.setValue('');
+            }
+            this._focusChipInput();
         }
 
         const alreadySelectedNormalValue = this.multiple &&

--- a/projects/angular/package.json
+++ b/projects/angular/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@uipath/angular",
-    "version": "15.0.2-rc.6",
+    "version": "15.0.2-rc.7",
     "license": "MIT",
     "author": {
         "name": "UiPath Inc",


### PR DESCRIPTION
With the MDC Components, the Checkbox inside a suggest's list option gets focused on click, making the input lose focus.

The behaviour is already ok if we try to select a new value, but if we search by an already selected value, deselect it by clicking on the checked Checkbox and then press ESC key, the dropdown is closed, the suggest input loses focus and the searched value is still there.

With this fix we'll clear the input and focus it after every selection/deselection.