### PR TITLE
feat(grid): add selectable page index

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# v15.0.10 (2023-12-04)
+* **grid** add selectable page index
+* **fix** increase loading buffer size
+
 # v15.0.9 (2023-11-24)
 * **grid** column width reacts on resize strategy changes
 * **grid** handle single sticky column case

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "angular-components",
-  "version": "15.0.9",
+  "version": "15.0.10",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "angular-components",
-      "version": "15.0.9",
+      "version": "15.0.10",
       "license": "MIT",
       "dependencies": {
         "@angular/animations": "15.2.9",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "angular-components",
-  "version": "15.0.9",
+  "version": "15.0.10",
   "author": {
     "name": "UiPath Inc",
     "url": "https://uipath.com"

--- a/projects/angular/components/ui-grid/src/components/ui-grid-custom-paginator/ui-grid-custom-paginator.component.html
+++ b/projects/angular/components/ui-grid/src/components/ui-grid-custom-paginator/ui-grid-custom-paginator.component.html
@@ -43,7 +43,27 @@
             </button>
             <div class="mat-mdc-paginator-page-label">
                 <ng-container *ngIf="!hideTotalCount">
-                    {{_intl.getPageLabel(pageIndex+1, pageCount)}}
+                    <ng-container *ngIf="selectablePageIndex && pageCount > 1; else defaultPageLabel">
+                        {{ _intl.getPageOnlyLabel() }}
+                        <mat-form-field [appearance]="_formFieldAppearance!"
+                                        [color]="color ?? 'primary'"
+                                        class="mat-mdc-paginator-page-index-select">
+                            <mat-select (selectionChange)="changePage($event.value)"
+                                        [value]="pageIndex"
+                                        [aria-label]="_intl.pageSelectLabel"
+                                        data-cy="page-index-select">
+                                <mat-option *ngFor="let possiblePage of possiblePages"
+                                            [value]="possiblePage.value">
+                                    {{ possiblePage.label }}
+                                </mat-option>
+                            </mat-select>
+                        </mat-form-field>
+                        {{ _intl.getTotalPages(pageCount) }}
+                    </ng-container>
+
+                    <ng-template #defaultPageLabel>
+                        {{_intl.getPageLabel(pageIndex+1, pageCount)}}
+                    </ng-template>
                 </ng-container>
                 <ng-container *ngIf="hideTotalCount">
                     {{ pageIndex + 1 }}

--- a/projects/angular/components/ui-grid/src/components/ui-grid-custom-paginator/ui-grid-custom-paginator.component.scss
+++ b/projects/angular/components/ui-grid/src/components/ui-grid-custom-paginator/ui-grid-custom-paginator.component.scss
@@ -8,6 +8,8 @@ $mat-paginator-selector-trigger-width: 56px;
 $mat-paginator-selector-trigger-outline-width: 64px;
 $mat-paginator-selector-trigger-fill-width: 64px;
 
+$mat-paginator-index-selector-width: 48px;
+
 $mat-paginator-page-label-margin: 0 32px 0 24px;
 $mat-paginator-button-icon-size: 14px;
 $mat-paginator-button-size: 32px;
@@ -54,6 +56,11 @@ ui-grid-custom-paginator {
     .mat-mdc-paginator-page-size-label {
         margin: $mat-paginator-items-per-page-label-margin;
     }
+    .mat-mdc-paginator-page-index-select {
+        margin: $mat-paginator-selector-margin;
+        width: $mat-paginator-index-selector-width;
+    }
+
     .mat-mdc-paginator-page-size-select {
         margin: $mat-paginator-selector-margin;
         width: $mat-paginator-selector-trigger-width;

--- a/projects/angular/components/ui-grid/src/components/ui-grid-custom-paginator/ui-grid-custom-paginator.component.ts
+++ b/projects/angular/components/ui-grid/src/components/ui-grid-custom-paginator/ui-grid-custom-paginator.component.ts
@@ -19,11 +19,21 @@ import {
 
 @Injectable()
 export class UiMatPaginatorIntl extends MatPaginatorIntl {
+    pageSelectLabel = 'Select page';
+
     getPageLabel(currentPage: number, pageCount?: number): string {
         if (!pageCount) {
             return `Page ${currentPage}`;
         }
         return `Page ${currentPage} / ${pageCount}`;
+    }
+
+    getPageOnlyLabel(): string {
+        return 'Page';
+    }
+
+    getTotalPages(pageCount: number): string {
+        return `/ ${pageCount}`;
     }
 }
 
@@ -46,8 +56,12 @@ export class UiGridCustomPaginatorComponent extends _MatPaginatorBase<MatPaginat
      * Whether to show total count in custom paginator
      *
      */
-    @Input()
-        hideTotalCount = false;
+    @Input() hideTotalCount = false;
+
+    /**
+     * Whether to be able to select the page index
+     */
+    @Input() selectablePageIndex = false;
 
     @HostBinding('class')
     hostClass = 'mat-mdc-paginator';
@@ -59,6 +73,20 @@ export class UiGridCustomPaginatorComponent extends _MatPaginatorBase<MatPaginat
     get totalCount(): number {
         return Math.min(this.length, (this.pageIndex + 1) * this.pageSize);
     }
+
+    set length(value: number) {
+        super.length = value;
+
+        this.possiblePages = Array.from({ length: this.pageCount }, (_, i) => ({
+            label: i + 1,
+            value: i,
+        }));
+    }
+    get length() {
+        return super.length;
+    }
+
+    possiblePages: { label: number; value: number }[] = [];
 
     constructor(
         changeDetectorRef: ChangeDetectorRef,
@@ -73,5 +101,18 @@ export class UiGridCustomPaginatorComponent extends _MatPaginatorBase<MatPaginat
         if (defaults?.formFieldAppearance != null) {
             this._formFieldAppearance = defaults.formFieldAppearance;
         }
+    }
+
+    changePage(pageIndex: number) {
+        const prevIndex = this.pageIndex;
+
+        this.pageIndex = pageIndex;
+
+        this.page.emit({
+            pageIndex,
+            previousPageIndex: prevIndex,
+            pageSize: this.pageSize,
+            length: this.length,
+        });
     }
 }

--- a/projects/angular/components/ui-grid/src/models/dataModel.ts
+++ b/projects/angular/components/ui-grid/src/models/dataModel.ts
@@ -29,4 +29,5 @@ export interface GridOptions<T> {
     idProperty?: keyof T;
     rowSize?: number;
     resizeStrategy?: ResizeStrategy;
+    selectablePageIndex?: boolean;
 }

--- a/projects/angular/components/ui-grid/src/ui-grid.component.html
+++ b/projects/angular/components/ui-grid/src/ui-grid.component.html
@@ -383,6 +383,7 @@
                                       [showFirstLastButtons]="footer.showFirstLastButtons"
                                       [hidePageSize]="footer.hidePageSize"
                                       [hideTotalCount]="footer.hideTotalCount"
+                                      [selectablePageIndex]="selectablePageIndex"
                                       (page)="footer.pageChange.next($event)">
             </ui-grid-custom-paginator>
         </div>

--- a/projects/angular/components/ui-grid/src/ui-grid.component.ts
+++ b/projects/angular/components/ui-grid/src/ui-grid.component.ts
@@ -439,6 +439,13 @@ export class UiGridComponent<T extends IGridDataEntry>
     }
 
     /**
+     * Configure if the pagination should be selectable
+     *
+     */
+    @Input()
+    selectablePageIndex: boolean;
+
+    /**
      * Emits an event with the sort model when a column sort changes.
      *
      */
@@ -867,6 +874,7 @@ export class UiGridComponent<T extends IGridDataEntry>
         this._collapseFiltersCount$ = new BehaviorSubject(
             _gridOptions?.collapseFiltersCount ?? (_gridOptions?.collapsibleFilters === true ? 0 : Number.POSITIVE_INFINITY),
         );
+        this.selectablePageIndex = _gridOptions?.selectablePageIndex ?? false;
 
         this.isProjected = this._ref.nativeElement.classList.contains('ui-grid-state-responsive');
 

--- a/projects/angular/package.json
+++ b/projects/angular/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@uipath/angular",
-    "version": "15.0.9",
+    "version": "15.0.10",
     "license": "MIT",
     "author": {
         "name": "UiPath Inc",

--- a/projects/playground/src/app/pages/grid/component/grid.component.html
+++ b/projects/playground/src/app/pages/grid/component/grid.component.html
@@ -17,7 +17,8 @@
          [expandMode]="'preserve'"
          [resizeStrategy]="inputs.isScrollable ? scrollableGridStrategy : immediateNeighbourHaltStrategy"
          [customFilterValue]="inputs.customFilter ? [{property: 'parity', method: 'eq', value: 'odd'}] : []"
-         [allowHighlight]="inputs.allowHighlight">
+         [allowHighlight]="inputs.allowHighlight"
+         [selectablePageIndex]="inputs.selectablePageIndex">
 
     <ui-grid-header [search]="header.searchable">
         <ui-header-button *ngFor="let button of generateButtons(header.main)"

--- a/projects/playground/src/app/pages/grid/grid.models.ts
+++ b/projects/playground/src/app/pages/grid/grid.models.ts
@@ -34,6 +34,7 @@ export interface IInputs {
     hideTotalCount: boolean;
     isScrollable: boolean;
     allowHighlight: boolean;
+    selectablePageIndex: boolean;
 }
 
 export interface IGridSettings {

--- a/projects/playground/src/app/pages/grid/grid.page.ts
+++ b/projects/playground/src/app/pages/grid/grid.page.ts
@@ -66,6 +66,7 @@ export class GridPageComponent implements AfterViewInit, OnDestroy {
         'useCardView',
         'isScrollable',
         'allowHighlight',
+        'selectablePageIndex',
     ];
 
     buttonKeys = [
@@ -131,6 +132,7 @@ export class GridPageComponent implements AfterViewInit, OnDestroy {
                 useCardView: [false],
                 isScrollable: [false],
                 allowHighlight: [false],
+                selectablePageIndex: [true],
             }),
             header: this._fb.group({
                 searchable: [true],


### PR DESCRIPTION
### Description
Adds the option to have selectable page index.
It is an input on `ui-grid` for individual usage, and it's also added to the `GRID_OPTIONS` injectable token so it can be enabled across.

### Demo
https://github.com/UiPath/angular-components/assets/9513641/c3586603-45fa-47ea-91f2-0009cee2394b
