### PR TITLE
fix: snackbar apply icon color

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# v15.1.1 (2023-12-28)
+* **snackbar** apply icon-color
+
 # v15.1.0 (2023-12-15)
 * **grid** drop unused customMenu directive
 * **grid** use suggest for multi filter dropdown

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "angular-components",
-  "version": "15.1.0",
+  "version": "15.1.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "angular-components",
-      "version": "15.1.0",
+      "version": "15.1.1",
       "license": "MIT",
       "dependencies": {
         "@angular/animations": "15.2.9",
@@ -6321,7 +6321,7 @@
       }
     },
     "node_modules/@rollup/plugin-node-resolve": {
-      "version": "15.1.0",
+      "version": "15.2.0",
       "resolved": "https://registry.npmjs.org/@rollup/plugin-node-resolve/-/plugin-node-resolve-15.1.0.tgz",
       "integrity": "sha512-xeZHCgsiZ9pzYVgAo9580eCGqwh/XCEUM9q6iQfGNocjgkufHAqC3exA+45URvhiYV8sBF9RlBai650eNs7AsA==",
       "dev": true,
@@ -19837,7 +19837,7 @@
       }
     },
     "node_modules/pacote": {
-      "version": "15.1.0",
+      "version": "15.2.0",
       "resolved": "https://registry.npmjs.org/pacote/-/pacote-15.1.0.tgz",
       "integrity": "sha512-FFcjtIl+BQNfeliSm7MZz5cpdohvUV1yjGnqgVM4UnVF7JslRY0ImXAygdaCDV0jjUADEWu4y5xsDV8brtrTLg==",
       "dev": true,
@@ -31322,7 +31322,7 @@
       }
     },
     "@rollup/plugin-node-resolve": {
-      "version": "15.1.0",
+      "version": "15.2.0",
       "resolved": "https://registry.npmjs.org/@rollup/plugin-node-resolve/-/plugin-node-resolve-15.1.0.tgz",
       "integrity": "sha512-xeZHCgsiZ9pzYVgAo9580eCGqwh/XCEUM9q6iQfGNocjgkufHAqC3exA+45URvhiYV8sBF9RlBai650eNs7AsA==",
       "dev": true,
@@ -41806,8 +41806,7 @@
       "dev": true
     },
     "pacote": {
-      "version": "15.1.0",
-      "resolved": "https://registry.npmjs.org/pacote/-/pacote-15.1.0.tgz",
+      "version": "https://registry.npmjs.org/pacote/-/pacote-15.1.0.tgz",
       "integrity": "sha512-FFcjtIl+BQNfeliSm7MZz5cpdohvUV1yjGnqgVM4UnVF7JslRY0ImXAygdaCDV0jjUADEWu4y5xsDV8brtrTLg==",
       "dev": true,
       "requires": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "angular-components",
-  "version": "15.1.0",
+  "version": "15.1.1",
   "author": {
     "name": "UiPath Inc",
     "url": "https://uipath.com"

--- a/projects/angular/components/ui-snackbar/src/_ui-snackbar.theme.scss
+++ b/projects/angular/components/ui-snackbar/src/_ui-snackbar.theme.scss
@@ -39,53 +39,40 @@ $default-snackbar-theme: (
 
     $success-text-color: map-get($success, "text");
     $success-background-color: map-get($success, "background");
+    $success-icon-color: map-get($success, "icon-color");
     $warning-text-color: map-get($warning, "text");
     $warning-background-color: map-get($warning, "background");
+    $warning-icon-color: map-get($warning, "icon-color");
     $error-text-color: map-get($error, "text");
     $error-background-color: map-get($error, "background");
+    $error-icon-color: map-get($error, "icon-color");
     $info-text-color: map-get($info, "text");
     $info-background-color: map-get($info, "background");
+    $info-icon-color: map-get($info, "icon-color");
 
     .ui-snackbar {
-        &-success,
-        &-warning,
-        &-error,
-        &-info {
-            mat-icon {
-                color: inherit;
-            }
-        }
-
         &-success {
-            color: $success-text-color;
-
-            .mdc-snackbar__surface {
-                background-color: $success-background-color;
-            }
+            --snackbar-text-color: #{$success-text-color};
+            --snackbar-background-color: #{$success-background-color};
+            --snackbar-icon-color: #{$success-icon-color};
         }
 
         &-warning {
-            color: $warning-text-color;
-
-            .mdc-snackbar__surface {
-                background-color: $warning-background-color;
-            }
+            --snackbar-text-color: #{$warning-text-color};
+            --snackbar-background-color: #{$warning-background-color};
+            --snackbar-icon-color: #{$warning-icon-color};
         }
 
         &-error {
-            color: $error-text-color;
-
-            .mdc-snackbar__surface {
-                background-color: $error-background-color;
-            }
+            --snackbar-text-color: #{$error-text-color};
+            --snackbar-background-color: #{$error-background-color};
+            --snackbar-icon-color: #{$error-icon-color};
         }
 
         &-info {
-            color: $info-text-color;
-
-            .mdc-snackbar__surface {
-                background-color: $info-background-color;
-            }
+            --snackbar-text-color: #{$info-text-color};
+            --snackbar-background-color: #{$info-background-color};
+            --snackbar-icon-color: #{$info-icon-color};
         }
 
         &-dismiss {

--- a/projects/angular/components/ui-snackbar/src/ui-snackbar.component.scss
+++ b/projects/angular/components/ui-snackbar/src/ui-snackbar.component.scss
@@ -2,6 +2,7 @@
     &-container {
         display: flex;
         justify-content: space-between;
+        color: var(--snackbar-text-color);
     }
 
     &-message,
@@ -17,6 +18,7 @@
     &-message {
         mat-icon {
             margin-right: 10px;
+            color: var(--snackbar-icon-color);
         }
         span {
             overflow-y: auto;
@@ -25,5 +27,9 @@
             line-height: 1.35em;
             word-break: break-word;
         }
+    }
+
+    .mdc-snackbar__surface {
+        background-color: var(--snackbar-background-color);
     }
 }

--- a/projects/angular/components/ui-snackbar/src/ui-snackbar.component.ts
+++ b/projects/angular/components/ui-snackbar/src/ui-snackbar.component.ts
@@ -162,6 +162,7 @@ interface ISnackBarOptions extends Partial<Exclude<ISnackBarAlert, 'closeAriaLab
     type?: SnackBarType;
 }
 
+const DEFAULT_PANEL_CLASS = 'ui-snackbar';
 export const panelClass = (type: SnackBarType) =>
     `ui-snackbar-${type}`;
 
@@ -280,7 +281,7 @@ export class UiSnackBarService {
                 ...options,
             },
             duration: options.duration,
-            panelClass: [panelClass(type), ...extraPanelClasses],
+            panelClass: [DEFAULT_PANEL_CLASS, panelClass(type), ...extraPanelClasses],
         });
 
         return this._ref;

--- a/projects/angular/package.json
+++ b/projects/angular/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@uipath/angular",
-    "version": "15.1.0",
+    "version": "15.1.1",
     "license": "MIT",
     "author": {
         "name": "UiPath Inc",


### PR DESCRIPTION
Consume icon-color coming from theme, and apply it based on snackbar level

Before:
![image](https://github.com/UiPath/angular-components/assets/6436378/553cb10d-3444-45f6-82db-6ed9e0c1079b)

After:
error
![image](https://github.com/UiPath/angular-components/assets/6436378/601c0add-747f-4b0f-bb48-71c637c2f2ec)

info
![image](https://github.com/UiPath/angular-components/assets/6436378/a3906a0a-b9bf-4f29-969b-c6ea86a47279)
