### PR TITLE
fix(file-picker): dropzone should only highlight when dragging files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# v15.1.4 (2024-02-02)
+* **file-picker** dropzone should only highlight when dragging files
+
 # v15.1.3 (2024-01-30)
 * **grid** exclude emtpy array from filter value
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "angular-components",
-  "version": "15.1.3",
+  "version": "15.1.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "angular-components",
-      "version": "15.1.3",
+      "version": "15.1.4",
       "license": "MIT",
       "dependencies": {
         "@angular/animations": "15.2.9",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "angular-components",
-  "version": "15.1.3",
+  "version": "15.1.4",
   "author": {
     "name": "UiPath Inc",
     "url": "https://uipath.com"

--- a/projects/angular/directives/ui-file-drop-zone/src/ui-file-drop-zone.directive.ts
+++ b/projects/angular/directives/ui-file-drop-zone/src/ui-file-drop-zone.directive.ts
@@ -63,22 +63,28 @@ export class UiFileDropZoneDirective implements OnInit, AfterViewInit, OnDestroy
         e.stopPropagation();
         e.preventDefault();
         this._dragCount -= 1;
-        this._clearDropZoneHighlight();
-        this.filesLoading.next(true);
-        this._fileReaderService.processDroppedItems(e);
+        const dragDataContainsFiles = this._dragEventContainsFiles(e);
+        if (dragDataContainsFiles) {
+            this._clearDropZoneHighlight();
+            this.filesLoading.next(true);
+            this._fileReaderService.processDroppedItems(e);
+        }
     }
 
     @HostListener('dragover', ['$event'])
     dragover(e: DragEvent) {
         // preventDefault is needed to enable drop event
         e.preventDefault();
+        const dragDataContainsFiles = this._dragEventContainsFiles(e);
+        if (this._dragCount > 0 && dragDataContainsFiles) {
+            this._highlightDropZone();
+        }
     }
 
     @HostListener('dragenter')
     dragenter() {
         if (!this.disabled) {
             this._dragCount += 1;
-            this._highlightDropZone();
         }
     }
 
@@ -135,5 +141,9 @@ export class UiFileDropZoneDirective implements OnInit, AfterViewInit, OnDestroy
             return;
         }
         this._dropZone.classList.remove(DROP_ZONE_HIGHLIGHT_CLASS);
+    }
+
+    private _dragEventContainsFiles(e: DragEvent) {
+        return e.dataTransfer?.types.includes('Files');
     }
 }

--- a/projects/angular/package.json
+++ b/projects/angular/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@uipath/angular",
-    "version": "15.1.3",
+    "version": "15.1.4",
     "license": "MIT",
     "author": {
         "name": "UiPath Inc",


### PR DESCRIPTION
## Description

- do not highlight drag area when dragging event does not contain Files

Before
![file-picker-disable-drag-anchors-before](https://github.com/UiPath/angular-components/assets/18557333/2f12af34-044f-4341-a2ae-c68aae81097a)

After
![file-picker-disable-drag-anchors-after](https://github.com/UiPath/angular-components/assets/18557333/d780ca1f-e736-41ac-a8df-663cf3e841cc)

