### PR TITLE
Fix: grid filter translations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
+# v15.2.2 (2024-02-16)
+* **grid** display margin shadow if scrollable
+* **suggest** change default forceDisplayDropdownOverInput
+* **grid** update filter options on lang change
+
 # v15.2.1 (2024-02-16)
 * **tree-select** add accessible props
+
+# v15.2.0 (2024-07-02)
+* **grid** add tests for high density mode
+* **grid** add support for high density mode
+* **grid** add tests for high density mode
+* **grid** add support for high density mode
+
+# v15.1.7 (2024-07-02)
+* **grid** add nullish for set items
 
 # v15.1.6 (2024-07-02)
 * **grid** react on max filters count changes

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "angular-components",
-  "version": "15.2.1",
+  "version": "15.2.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "angular-components",
-      "version": "15.2.1",
+      "version": "15.2.2",
       "license": "MIT",
       "dependencies": {
         "@angular/animations": "15.2.9",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "angular-components",
-  "version": "15.2.1",
+  "version": "15.2.2",
   "author": {
     "name": "UiPath Inc",
     "url": "https://uipath.com"

--- a/projects/angular/components/ui-grid/src/_ui-grid-variables.scss
+++ b/projects/angular/components/ui-grid/src/_ui-grid-variables.scss
@@ -6,3 +6,4 @@ $ui-grid-header-pressed-color: var(--color-data-grid-pressed, #EAECED);
 $header-background-color:  var(--color-background-secondary, #f4f5f7);
 $grid-actions-box-shadow: var(--color-background, #ffffff);
 $highlighted-entity-color: var(--color-primary, #0067df);
+$scroll-margin-shadow-color: var(--color-background-inverse, #182027);

--- a/projects/angular/components/ui-grid/src/_ui-grid.theme.scss
+++ b/projects/angular/components/ui-grid/src/_ui-grid.theme.scss
@@ -215,6 +215,18 @@ $ui-grid-opacity-transition: opacity $ui-grid-default-transition;
                     background-color: $ui-grid-row-hover-color;
                 }
             }
+
+            .grid-margin-shadow {
+                position: sticky;
+                right: 0;
+                height: 100%;
+
+                @if $is-dark {
+                    box-shadow: -7px 20px 20px 4px #000000;
+                } @else {
+                    box-shadow: -3px 5px 20px 1.6px $scroll-margin-shadow-color;
+                }
+            }
         }
 
         .ui-grid-sort-icon {

--- a/projects/angular/components/ui-grid/src/test/column.ts
+++ b/projects/angular/components/ui-grid/src/test/column.ts
@@ -1,3 +1,4 @@
+import { TestBed } from '@angular/core/testing';
 import * as faker from 'faker';
 import { of } from 'rxjs';
 
@@ -20,7 +21,10 @@ export const generateColumn = () => {
 };
 
 export const generateDropdownFilter = () => {
-    const dropdown = new UiGridDropdownFilterDirective<ITestEntity>();
+    let dropdown!: UiGridDropdownFilterDirective<ITestEntity>;
+    TestBed.runInInjectionContext(() => {
+        dropdown = new UiGridDropdownFilterDirective<ITestEntity>();
+    });
 
     const items = faker.random.words(15)
         .split(' ')

--- a/projects/angular/components/ui-grid/src/ui-grid.component.html
+++ b/projects/angular/components/ui-grid/src/ui-grid.component.html
@@ -749,7 +749,7 @@
                             [searchable]="false"
                             [value]="suggestValue"
                             [placeholder]="column.title ?? ''"
-                            [items]="mapFilterOptions(column.dropdown!.suggestItems, column)"
+                            [items]="column.dropdown!.suggestItems"
                             [compactSummaryTemplate]="displayedFilterName"
                             [maxSelectionConfig]="{
                                 count: (disableFilterSelection$ | async) && (column.dropdown!.multi || selectedFilters === undefined) ? suggestValue.length : Infinity,
@@ -768,10 +768,9 @@
                     <div class="flex">
                         <span class="text-ellipsis">
                             {{ (column.dropdown!.multi && selectedFilters?.length > 1)
-                            ? intl.translateMultiDropdownOptions(value?.[0]?.text, selectedFilters.length)
-                                : value?.[0]
-                                ? intl.translateDropdownOption(column.dropdown!.findDropDownOptionBySuggestValue(value[0])!)
-                            : intl.noFilterPlaceholder }}</span>
+                                ? intl.translateMultiDropdownOptions(value[0].text!, selectedFilters.length)
+                                : value?.[0]?.text ?? intl.noFilterPlaceholder
+                            }}</span>
                     </div>
                 </ng-template>
             </ng-container>

--- a/projects/angular/components/ui-grid/src/ui-grid.component.html
+++ b/projects/angular/components/ui-grid/src/ui-grid.component.html
@@ -283,6 +283,7 @@
                          class="ui-grid-header-cell ui-grid-scroll-size-compensation-cell ui-grid-feature-cell">
                     </div>
                     <div *ngIf="refreshable"
+                         [class.refresh-shadow]="shouldDisplayContainerShadow$ | async"
                          class="ui-grid-header-cell ui-grid-refresh-cell ui-grid-feature-cell"
                          role="columnheader">
                         <button [matTooltip]="intl.refreshTooltip"
@@ -565,9 +566,13 @@
              class="ui-grid-cell ui-grid-refresh-cell ui-grid-feature-cell">
         </div>
 
+        <div *ngIf="!actions && (shouldDisplayContainerShadow$ | async)"
+             class="grid-margin-shadow ui-grid-feature-cell"></div>
+
         <div *ngIf="!isProjected &&
                     !!actions"
              [class.ui-grid-sticky-element]="isScrollable"
+             [class.grid-margin-shadow]="shouldDisplayContainerShadow$ | async"
              role="gridcell"
              class="ui-grid-cell ui-grid-action-cell ui-grid-feature-cell">
             <div [class.sticky-grid-action-cell-container]="isScrollable"

--- a/projects/angular/components/ui-grid/src/ui-grid.component.scss
+++ b/projects/angular/components/ui-grid/src/ui-grid.component.scss
@@ -693,6 +693,10 @@ ui-grid {
                 &.ui-grid-refresh-cell {
                     position: sticky;
                     right: 0;
+
+                    &.refresh-shadow {
+                        box-shadow: -16px 0px 16px -4px $ui-grid-row-hover-color;
+                    }
                 }
 
                 &.ui-grid-action-cell {

--- a/projects/angular/components/ui-grid/src/ui-grid.component.spec.ts
+++ b/projects/angular/components/ui-grid/src/ui-grid.component.spec.ts
@@ -4856,6 +4856,13 @@ describe('Component: UiGrid', () => {
                 expect(gridTable.nativeElement.style.minWidth).toBe(columnWidthSum + 'px');
             }));
 
+            it('should display margin shadow when the grid has horizontal scroll', fakeAsync(() => {
+                const widths = [250, 1000, 330, 400, 100, 100]; // large enough too cause overflow
+                beforeConfig({ widths });
+                const tableMarginShadowDivs = fixture.debugElement.queryAll(By.css('.grid-margin-shadow'));
+                expect(tableMarginShadowDivs.length).toBe(widths.length);
+            }));
+
             it('should increase the width of last column if default column width sum does not fill the table', fakeAsync(() => {
                 const widths = [50, 50, 0, 50, 50, 50];
                 const lastColumnIdx = 4; // refresh btn & 1 missing column
@@ -5028,13 +5035,13 @@ describe('Component: UiGrid', () => {
                     expect(+newMinWidth.replace('px', '')).toBeLessThan(+startingMinWidth.replace('px', ''));
                 }));
 
-                it(`should set overflow to visible if total width of columns does not exceed container width`, fakeAsync(() => {
+                it(`should set overflow to visible and hide margin shadow if total width of columns does not exceed container width`, fakeAsync(() => {
                     const gridTable = fixture.debugElement.query(By.css('.ui-grid-table'));
                     const options = fixture.debugElement
                         .queryAll(By.css('.ui-grid-toggle-panel .mat-mdc-option:not(.mdc-list-item--disabled)'));
 
                     expect(gridTable.styles.overflow).toEqual('visible');
-
+                    expect(fixture.debugElement.queryAll(By.css('.grid-margin-shadow')).length).toBe(6);
                     options.forEach(o => {
                         const checkbox = o.query(By.css('.mat-pseudo-checkbox'));
                         checkbox.nativeElement.dispatchEvent(EventGenerator.click);
@@ -5044,6 +5051,7 @@ describe('Component: UiGrid', () => {
                     fixture.detectChanges();
 
                     expect(gridTable.styles.overflow).toEqual('hidden');
+                    expect(fixture.debugElement.queryAll(By.css('.grid-margin-shadow')).length).toBe(0);
                 }));
             });
 

--- a/projects/angular/components/ui-grid/src/ui-grid.component.spec.ts
+++ b/projects/angular/components/ui-grid/src/ui-grid.component.spec.ts
@@ -1488,14 +1488,21 @@ describe('Component: UiGrid', () => {
         let fixture: ComponentFixture<TestFixtureGridHeaderWithFilterComponent>;
         let component: TestFixtureGridHeaderWithFilterComponent;
         let grid: UiGridComponent<ITestEntity>;
-
+        let intl: UiGridIntl;
         beforeEach(() => {
+            intl = new UiGridIntl();
             TestBed.configureTestingModule({
                 imports: [
                     UiGridModule,
                     NoopAnimationsModule,
                 ],
                 declarations: [TestFixtureGridHeaderWithFilterComponent],
+                providers: [
+                    {
+                        provide: UiGridIntl,
+                        useValue: intl,
+                    },
+                ],
             });
 
             fixture = TestBed.createComponent(TestFixtureGridHeaderWithFilterComponent);
@@ -1520,6 +1527,28 @@ describe('Component: UiGrid', () => {
                 component.dropdownItemList = dropdownItemList;
                 fixture.detectChanges();
             });
+
+            it('should update translation for filter options when language changes', fakeAsync(() => {
+                intl.translateDropdownOption = () => 'voila la traduction';
+                intl.changes.next();
+                fixture.detectChanges();
+
+                const filterContainer = fixture.debugElement.query(By.css('.ui-grid-dropdown-filter-container'));
+                const filterButton = filterContainer.query(By.css(selectors.filterDropdown));
+                filterButton.nativeElement.dispatchEvent(EventGenerator.click);
+                fixture.detectChanges();
+                tick(1000);
+                fixture.detectChanges();
+
+                const filterCheckboxes = fixture.debugElement.queryAll(By.css('mat-list-item mat-checkbox'));
+                filterCheckboxes[0].nativeElement.dispatchEvent(EventGenerator.click);
+                filterCheckboxes[1].nativeElement.dispatchEvent(EventGenerator.click);
+                fixture.detectChanges();
+
+                const filterSpan = fixture.debugElement.query(By.css('.ui-grid-filter-suggest span.text-ellipsis'));
+                expect(filterSpan.nativeElement.innerText).toEqual('voila la traduction (+1 other)');
+                flush();
+            }));
 
             it('should emit all selected filter options', fakeAsync(() => {
                 const filterContainer = fixture.debugElement.query(By.css('.ui-grid-dropdown-filter-container'));

--- a/projects/angular/components/ui-grid/src/ui-grid.component.ts
+++ b/projects/angular/components/ui-grid/src/ui-grid.component.ts
@@ -65,10 +65,7 @@ import {
 } from '@angular/material/checkbox';
 import { MatTooltip } from '@angular/material/tooltip';
 import { QueuedAnnouncer } from '@uipath/angular/a11y';
-import {
-    ISuggestValue,
-    ISuggestValueData,
-} from '@uipath/angular/components/ui-suggest';
+import { ISuggestValue } from '@uipath/angular/components/ui-suggest';
 
 import { UiGridColumnDirective } from './body/ui-grid-column.directive';
 import { UiGridExpandedRowDirective } from './body/ui-grid-expanded-row.directive';
@@ -78,7 +75,6 @@ import { UiGridRowActionDirective } from './body/ui-grid-row-action.directive';
 import { UiGridRowCardViewDirective } from './body/ui-grid-row-card-view.directive';
 import { UiGridRowConfigDirective } from './body/ui-grid-row-config.directive';
 import { UiGridCustomSearchDirective } from './components/ui-grid-search/ui-grid-custom-search.directive';
-import { ISuggestDropdownValueData } from './filters/ui-grid-dropdown-filter.directive';
 import { UiGridSearchFilterDirective } from './filters/ui-grid-search-filter.directive';
 import { UiGridFooterDirective } from './footer/ui-grid-footer.directive';
 import { UiGridHeaderDirective } from './header/ui-grid-header.directive';
@@ -1284,26 +1280,6 @@ export class UiGridComponent<T extends IGridDataEntry>
             (isArray(column.dropdown.value) || column.dropdown!.value.value !== column.dropdown.emptyStateValue);
 
         return dropdownHasValue || searchableHasValue;
-    }
-
-    mapFilterOptions(items: ISuggestDropdownValueData[], column: UiGridColumnDirective<T>) {
-        items = items
-            .filter(item => !!column.dropdown!.findDropDownOptionBySuggestValue(item))
-            .map(item => {
-                const translatedText = this.intl.translateDropdownOption(column.dropdown!.findDropDownOptionBySuggestValue(item)!);
-                return {
-                    ...item,
-                    text: translatedText,
-                };
-            });
-
-        if (column.dropdown?.multi || !column.dropdown?.showAllOption) { return items; }
-
-        const allOption: ISuggestValueData<undefined> = {
-            id: -1,
-            text: this.intl.noFilterPlaceholder,
-        };
-        return items.some(v => v.data === undefined) ? items : [allOption, ...items];
     }
 
     triggerColumnHeaderTooltip(event: FocusOrigin, tooltip: MatTooltip) {

--- a/projects/angular/components/ui-grid/src/ui-grid.component.ts
+++ b/projects/angular/components/ui-grid/src/ui-grid.component.ts
@@ -5,6 +5,8 @@ import {
     BehaviorSubject,
     combineLatest,
     defer,
+    fromEvent,
+    iif,
     merge,
     Observable,
     of,
@@ -25,6 +27,7 @@ import {
     take,
     takeUntil,
     tap,
+    throttleTime,
 } from 'rxjs/operators';
 
 import {
@@ -110,6 +113,7 @@ const EXCLUDED_ROW_SELECTION_ELEMENTS = ['a', 'button', 'input', 'textarea', 'se
 const REFRESH_WIDTH = 50;
 const DEFAULT_VIRTUAL_SCROLL_ITEM_SIZE = 48;
 const DEFAULT_VIRTUAL_SCROLL_HIGH_DENSITY_ITEM_SIZE = 32;
+const SCROLL_LIMIT_FOR_DISPLAYING_SHADOW = 10;
 
 @Component({
     selector: 'ui-grid',
@@ -827,6 +831,20 @@ export class UiGridComponent<T extends IGridDataEntry>
         shareReplay(1),
     );
 
+    shouldDisplayContainerShadow$ = defer(() => merge(
+        fromEvent(this._ref.nativeElement.querySelector('.ui-grid-table-container')!, 'scroll').pipe(
+            throttleTime(50, undefined, { trailing: true }),
+            map((event: any) => {
+                const { scrollWidth, scrollLeft, clientWidth } = event.target;
+                return Math.abs(scrollWidth - clientWidth - scrollLeft) >= SCROLL_LIMIT_FOR_DISPLAYING_SHADOW;
+            }),
+        ),
+        this.isOverflown$,
+    )).pipe(
+        distinctUntilChanged(),
+        shareReplay(),
+    );
+
     areFilersCollapsed$: Observable<boolean>;
 
     /**
@@ -862,10 +880,10 @@ export class UiGridComponent<T extends IGridDataEntry>
         shareReplay(1),
     );
 
-    isOverflown$ = this.minWidth$.pipe(
+    isOverflown$ = iif(() => this.isScrollable, this.minWidth$.pipe(
         map(minWidth => this._isOverflown(minWidth)),
         distinctUntilChanged(),
-    );
+    ), of(false));
 
     tableOverflowStyle$ = this.isOverflown$.pipe(
         map(value => value ? 'visible' : 'hidden'),
@@ -1342,7 +1360,6 @@ export class UiGridComponent<T extends IGridDataEntry>
         }, 0);
 
         return widthsPxSum + this._otherActionsWidth;
-
     }
 
     private get _otherActionsWidth() {

--- a/projects/angular/components/ui-suggest/src/ui-suggest.component.ts
+++ b/projects/angular/components/ui-suggest/src/ui-suggest.component.ts
@@ -244,7 +244,7 @@ export class UiSuggestComponent extends UiSuggestMatFormFieldDirective
      * If true, component wil place the dropdown over the input
      */
     @Input()
-    forceDisplayDropdownOverInput = false;
+    forceDisplayDropdownOverInput = true;
 
     /**
      * Configure if the component allows multi-selection.

--- a/projects/angular/package.json
+++ b/projects/angular/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@uipath/angular",
-    "version": "15.2.1",
+    "version": "15.2.2",
     "license": "MIT",
     "author": {
         "name": "UiPath Inc",


### PR DESCRIPTION
- fix translations for grid options when changing the lang
- add margin shadow to table and fade effect near the refresh button when grid is scrollable.  

Light theme:

![image](https://github.com/UiPath/angular-components/assets/87014385/e0f7118b-16b8-470d-9410-b89daf1b3afe)


Dark theme: 

![image](https://github.com/UiPath/angular-components/assets/87014385/38b86d6b-7e4b-4c27-b864-291959997c2c)
